### PR TITLE
fix: resolve #[RequestParam] annotations before filtering in processRequest() flow

### DIFF
--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -522,7 +522,11 @@ class WebServicesManager implements JsonI {
                     $this->configureServiceParameters($actionObj);
                 }
 
-                $params = $actionObj->getParameters();
+                // Resolve #[RequestParam] annotations for the current HTTP method.
+                // This ensures annotated parameters are registered before filtering,
+                // even for services using the traditional processRequest() pattern.
+                $actionObj->getParameterByName('', $this->getRequest()->getRequestMethod());
+
                 $params = $actionObj->getParameters();
                 $this->filter->clearParametersDef();
                 $this->filter->clearInputs();

--- a/tests/WebFiori/Tests/Http/AnnotatedParamsProcessRequestTest.php
+++ b/tests/WebFiori/Tests/Http/AnnotatedParamsProcessRequestTest.php
@@ -1,0 +1,117 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\AnnotatedParamsLegacyService;
+use WebFiori\Tests\Http\TestServices\AnnotatedService;
+
+/**
+ * Tests that #[RequestParam] annotations are resolved before filtering
+ * in WebServicesManager::process(), for services using the traditional
+ * processRequest() pattern (without #[ResponseBody]).
+ *
+ * Regression test for: https://github.com/WebFiori/http/issues/102
+ */
+class AnnotatedParamsProcessRequestTest extends APITestCase {
+
+    /**
+     * Test that POST parameters are received via processRequest() when
+     * using #[RequestParam] annotations without #[ResponseBody].
+     */
+    public function testPostParamsResolvedInProcessRequest() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedParamsLegacyService());
+
+        $output = $this->postRequest($manager, 'annotated-params-legacy', [
+            'username' => 'admin@test.com',
+            'password' => 'secret123',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('success', $response['type']);
+        $this->assertStringContainsString('admin@test.com', $response['message']);
+    }
+
+    /**
+     * Test that missing required parameters are correctly reported
+     * when using #[RequestParam] annotations without #[ResponseBody].
+     */
+    public function testMissingParamsReportedInProcessRequest() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedParamsLegacyService());
+
+        $output = $this->postRequest($manager, 'annotated-params-legacy', []);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        // Framework should report missing required params
+        $this->assertArrayHasKey('missing', $response['more-info']);
+        $this->assertContains('username', $response['more-info']['missing']);
+        $this->assertContains('password', $response['more-info']['missing']);
+    }
+
+    /**
+     * Test that partially missing parameters are reported.
+     */
+    public function testPartialParamsMissing() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedParamsLegacyService());
+
+        $output = $this->postRequest($manager, 'annotated-params-legacy', [
+            'username' => 'admin@test.com',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertContains('password', $response['more-info']['missing']);
+    }
+
+    /**
+     * Test that #[ResponseBody] services still work correctly after the fix.
+     * This ensures the fix doesn't break the existing auto-processing path.
+     */
+    public function testResponseBodyServiceStillWorks() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedService());
+
+        $output = $this->getRequest($manager, 'annotated-service', [
+            'name' => 'Ibrahim',
+        ]);
+
+        $this->assertStringContainsString('Hi Ibrahim!', $output);
+    }
+
+    /**
+     * Test that #[ResponseBody] service with no params still works.
+     */
+    public function testResponseBodyServiceNoParams() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedService());
+
+        $output = $this->getRequest($manager, 'annotated-service');
+
+        $this->assertStringContainsString('Hi user!', $output);
+    }
+
+    /**
+     * Test wrong HTTP method is rejected for annotated legacy service.
+     */
+    public function testWrongMethodRejected() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedParamsLegacyService());
+
+        // Service only accepts POST, sending GET should fail
+        $output = $this->getRequest($manager, 'annotated-params-legacy', [
+            'username' => 'admin@test.com',
+            'password' => 'secret123',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/AnnotatedParamsLegacyService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/AnnotatedParamsLegacyService.php
@@ -1,0 +1,41 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\WebService;
+
+/**
+ * A service that uses #[RequestParam] annotations with the traditional
+ * processRequest() pattern (no #[ResponseBody]).
+ * This is the pattern that was broken before the fix.
+ */
+#[RestController('annotated-params-legacy')]
+class AnnotatedParamsLegacyService extends WebService {
+    public function isAuthorized(): bool {
+        return true;
+    }
+
+    #[PostMapping]
+    #[RequestParam(name: 'username', type: ParamType::STRING)]
+    #[RequestParam(name: 'password', type: ParamType::STRING)]
+    public function processRequest() {
+        $username = $this->getParamVal('username');
+        $password = $this->getParamVal('password');
+
+        if ($username === null) {
+            $this->sendResponse('Username is missing', 400, 'error');
+            return;
+        }
+
+        if ($password === null) {
+            $this->sendResponse('Password is missing', 400, 'error');
+            return;
+        }
+
+        $this->sendResponse('Login successful for: ' . $username, 200, 'success');
+    }
+}


### PR DESCRIPTION
# Summary
Resolves `#[RequestParam]` annotations not being processed before input filtering for services using the traditional `processRequest()` pattern (without `#[ResponseBody]`).

## Motivation
Services that use `#[RequestParam]` annotations on `processRequest()` always receive `null` from `getParamVal()` because the annotations are never resolved before the filter runs. This only affects the `processRequest()` path — `#[ResponseBody]` services work correctly. Fixes #102.

## Changes
- Added a call to `$actionObj->getParameterByName('',$this->getRequest()->getRequestMethod())` in `WebServicesManager::process()` before `getParameters()` is called. This triggers the lazy annotation resolution for the current HTTP method, ensuring `#[RequestParam]` parameters are registered in the filter for all services.
- Added `AnnotatedParamsLegacyService` test service that uses `#[RequestParam]` with `processRequest()`.
- Added `AnnotatedParamsProcessRequestTest` with 6 test cases covering the fix and regression checks.

## How to Test / Verify
Unit tests:
```bash
php vendor/bin/phpunit --configuration tests/phpunit10.xml --filter AnnotatedParamsProcessRequestTest
```

Full suite (422 tests, 0 failures):
```bash
php vendor/bin/phpunit --configuration tests/phpunit10.xml
```

Test cases:
1. POST params are correctly received via `processRequest()` with `#[RequestParam]` annotations
2. Missing required params are reported by the framework
3. Partially missing params are reported
4. `#[ResponseBody]` services still work (regression check)
5. `#[ResponseBody]` services with no params still work (regression check)
6. Wrong HTTP method is rejected

## Breaking Changes and Migration Steps
None. This is a purely additive fix. The `getParameterByName()` call is a no-op when annotations have already been resolved (e.g., for `#[ResponseBody]` services), so existing behavior is unchanged.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #102