### PR TITLE
feat(#114): add allowed-values and pattern validation to RequestParameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ ParamOption::MAX_LENGTH   // Maximum length (string types)
 ParamOption::EMPTY        // Allow empty strings
 ParamOption::FILTER       // Custom filter function
 ParamOption::DESCRIPTION  // Parameter description
+ParamOption::ALLOWED_VALUES // Restrict to a set of allowed values
+ParamOption::PATTERN      // Regex pattern for validation
 ```
 
 ### Custom Validation

--- a/WebFiori/Http/APIFilter.php
+++ b/WebFiori/Http/APIFilter.php
@@ -383,6 +383,10 @@ class APIFilter {
             }
         }
 
+        if ($returnVal !== self::INVALID) {
+            $returnVal = self::checkAllowedAndPattern($returnVal, $paramObj);
+        }
+
         return $returnVal;
     }
     private static function applyCustomFilterFunc($def, $toBeFiltered) {
@@ -544,6 +548,11 @@ class APIFilter {
         $cleaned = $extraClean->get($name);
 
         if (strlen($cleaned) == 0 && $def['options']['options']['allow-empty'] === false) {
+            $extraClean->add($name, null);
+            return;
+        }
+
+        if ($cleaned !== null && self::checkAllowedAndPattern($cleaned, $def['parameter']) === self::INVALID) {
             $extraClean->add($name, null);
         }
     }
@@ -964,5 +973,28 @@ class APIFilter {
         }
 
         return false;
+    }
+    /**
+     * Checks allowed values and pattern constraints on a filtered value.
+     * 
+     * @param mixed $value The filtered value.
+     * @param RequestParameter $param The parameter definition.
+     * 
+     * @return mixed The value if valid, or self::INVALID if constraints fail.
+     */
+    private static function checkAllowedAndPattern($value, RequestParameter $param) {
+        $allowed = $param->getAllowedValues();
+
+        if (!empty($allowed) && !in_array($value, $allowed, true)) {
+            return self::INVALID;
+        }
+
+        $pattern = $param->getPattern();
+
+        if ($pattern !== null && is_string($value) && !preg_match($pattern, $value)) {
+            return self::INVALID;
+        }
+
+        return $value;
     }
 }

--- a/WebFiori/Http/Annotations/RequestParam.php
+++ b/WebFiori/Http/Annotations/RequestParam.php
@@ -21,7 +21,9 @@ class RequestParam {
         public readonly bool $optional = false,
         public readonly mixed $default = null,
         public readonly string $description = '',
-        public readonly mixed $filter = null
+        public readonly mixed $filter = null,
+        public readonly array $allowedValues = [],
+        public readonly ?string $pattern = null
     ) {
     }
 }

--- a/WebFiori/Http/OpenAPI/Schema.php
+++ b/WebFiori/Http/OpenAPI/Schema.php
@@ -81,6 +81,18 @@ class Schema {
         $schema->default = $param->getDefault();
         $schema->description = $param->getDescription();
 
+        if (!empty($param->getAllowedValues())) {
+            $schema->setEnum($param->getAllowedValues());
+        }
+
+        if ($param->getPattern() !== null) {
+            // Strip PHP regex delimiters for OpenAPI (ECMA-262 format)
+            $pattern = $param->getPattern();
+            $delimiter = $pattern[0];
+            $lastPos = strrpos($pattern, $delimiter);
+            $schema->setPattern(substr($pattern, 1, $lastPos - 1));
+        }
+
         return $schema;
     }
 

--- a/WebFiori/Http/ParamOption.php
+++ b/WebFiori/Http/ParamOption.php
@@ -22,6 +22,14 @@ class ParamOption {
      */
     const DEFAULT = 'default';
     /**
+     * An option which is used to restrict parameter value to a set of allowed values.
+     */
+    const ALLOWED_VALUES = 'allowed-values';
+    /**
+     * An option which is used to set a regex pattern for string validation.
+     */
+    const PATTERN = 'pattern';
+    /**
      * An option which is used to set a description for the parameter
      */
     const DESCRIPTION = 'description';

--- a/WebFiori/Http/ParamOption.php
+++ b/WebFiori/Http/ParamOption.php
@@ -17,6 +17,10 @@ namespace WebFiori\Http;
  */
 class ParamOption {
     /**
+     * An option which is used to restrict parameter value to a set of allowed values.
+     */
+    const ALLOWED_VALUES = 'allowed-values';
+    /**
      * An option which is used to set default value if parameter is optional and
      * not provided.
      */
@@ -63,6 +67,10 @@ class ParamOption {
      * An option which is used to indicate that a parameter is optional or not (bool). Applies to all data types.
      */
     const OPTIONAL = 'optional';
+    /**
+     * An option which is used to set a regex pattern for string validation.
+     */
+    const PATTERN = 'pattern';
     /**
      * Parameter type option. Applies to all data types.
      */

--- a/WebFiori/Http/RequestParameter.php
+++ b/WebFiori/Http/RequestParameter.php
@@ -31,6 +31,12 @@ class RequestParameter implements JsonI {
      * @var array
      */
     public const RESERVED_NAMES = ['action', 'service', 'service-name'];
+    /**
+     * An array of allowed values for the parameter.
+     * 
+     * @var array
+     */
+    private $allowedValues;
 
 
     /** A boolean value that is set to true in case the 
@@ -118,6 +124,12 @@ class RequestParameter implements JsonI {
      */
     private $name;
     /**
+     * A regex pattern for validating string parameters.
+     * 
+     * @var string|null
+     */
+    private $pattern;
+    /**
      * The type of the data the parameter will represent.
      * 
      * @var string
@@ -167,6 +179,8 @@ class RequestParameter implements JsonI {
         $this->applyBasicFilter = true;
         $this->isEmptyStrAllowed = false;
         $this->methods = [];
+        $this->allowedValues = [];
+        $this->pattern = null;
     }
     /**
      * Returns a string that represents the object.
@@ -287,6 +301,14 @@ class RequestParameter implements JsonI {
         return null;
     }
     /**
+     * Returns the array of allowed values for the parameter.
+     * 
+     * @return array The allowed values. Empty array means no restriction.
+     */
+    public function getAllowedValues() : array {
+        return $this->allowedValues;
+    }
+    /**
      * Returns the function that is used as a custom filter 
      * for the parameter.
      * 
@@ -389,6 +411,14 @@ class RequestParameter implements JsonI {
         return $this->name;
     }
     /**
+     * Returns the regex pattern used for validation.
+     * 
+     * @return string|null The pattern or null if not set.
+     */
+    public function getPattern() : ?string {
+        return $this->pattern;
+    }
+    /**
      * Returns the type of the parameter.
      * 
      * @return string The type of the parameter (Such as 'string', 'email', 'integer').
@@ -433,6 +463,14 @@ class RequestParameter implements JsonI {
      */
     public function isOptional() : bool {
         return $this->isOptional;
+    }
+    /**
+     * Sets the allowed values for the parameter.
+     * 
+     * @param array $values An array of permitted values.
+     */
+    public function setAllowedValues(array $values) : void {
+        $this->allowedValues = $values;
     }
     /**
      * Sets a callback method to work as a filter for request parameter.
@@ -700,6 +738,22 @@ class RequestParameter implements JsonI {
         return false;
     }
     /**
+     * Sets a regex pattern for validating the parameter value.
+     * 
+     * @param string $regex A valid PHP regex (e.g. '/^[a-z]+$/').
+     * 
+     * @return bool True if the regex is valid and was set, false otherwise.
+     */
+    public function setPattern(string $regex) : bool {
+        if (@preg_match($regex, '') !== false) {
+            $this->pattern = $regex;
+
+            return true;
+        }
+
+        return false;
+    }
+    /**
      * Sets the type of the parameter.
      * 
      * @param string $type The type of the parameter. It must be a value 
@@ -817,6 +871,14 @@ class RequestParameter implements JsonI {
 
         if (isset($options[ParamOption::DESCRIPTION])) {
             $param->setDescription($options[ParamOption::DESCRIPTION]);
+        }
+
+        if (isset($options[ParamOption::ALLOWED_VALUES])) {
+            $param->setAllowedValues($options[ParamOption::ALLOWED_VALUES]);
+        }
+
+        if (isset($options[ParamOption::PATTERN])) {
+            $param->setPattern($options[ParamOption::PATTERN]);
         }
     }
     private function getSchema() : Json {

--- a/WebFiori/Http/RequestParameter.php
+++ b/WebFiori/Http/RequestParameter.php
@@ -125,6 +125,18 @@ class RequestParameter implements JsonI {
      */
     private $type;
     /**
+     * An array of allowed values for the parameter.
+     * 
+     * @var array
+     */
+    private $allowedValues;
+    /**
+     * A regex pattern for validating string parameters.
+     * 
+     * @var string|null
+     */
+    private $pattern;
+    /**
      * Creates new instance of the class.
      * 
      * @param string $name The name of the parameter as it appears in the request body. 
@@ -167,6 +179,8 @@ class RequestParameter implements JsonI {
         $this->applyBasicFilter = true;
         $this->isEmptyStrAllowed = false;
         $this->methods = [];
+        $this->allowedValues = [];
+        $this->pattern = null;
     }
     /**
      * Returns a string that represents the object.
@@ -396,6 +410,44 @@ class RequestParameter implements JsonI {
      */
     public function getType() : string {
         return $this->type;
+    }
+    /**
+     * Returns the array of allowed values for the parameter.
+     * 
+     * @return array The allowed values. Empty array means no restriction.
+     */
+    public function getAllowedValues() : array {
+        return $this->allowedValues;
+    }
+    /**
+     * Sets the allowed values for the parameter.
+     * 
+     * @param array $values An array of permitted values.
+     */
+    public function setAllowedValues(array $values) : void {
+        $this->allowedValues = $values;
+    }
+    /**
+     * Returns the regex pattern used for validation.
+     * 
+     * @return string|null The pattern or null if not set.
+     */
+    public function getPattern() : ?string {
+        return $this->pattern;
+    }
+    /**
+     * Sets a regex pattern for validating the parameter value.
+     * 
+     * @param string $regex A valid PHP regex (e.g. '/^[a-z]+$/').
+     * 
+     * @return bool True if the regex is valid and was set, false otherwise.
+     */
+    public function setPattern(string $regex) : bool {
+        if (@preg_match($regex, '') !== false) {
+            $this->pattern = $regex;
+            return true;
+        }
+        return false;
     }
     /**
      * Checks if we need to apply basic filter or not 
@@ -817,6 +869,14 @@ class RequestParameter implements JsonI {
 
         if (isset($options[ParamOption::DESCRIPTION])) {
             $param->setDescription($options[ParamOption::DESCRIPTION]);
+        }
+
+        if (isset($options[ParamOption::ALLOWED_VALUES])) {
+            $param->setAllowedValues($options[ParamOption::ALLOWED_VALUES]);
+        }
+
+        if (isset($options[ParamOption::PATTERN])) {
+            $param->setPattern($options[ParamOption::PATTERN]);
         }
     }
     private function getSchema() : Json {

--- a/WebFiori/Http/WebService.php
+++ b/WebFiori/Http/WebService.php
@@ -1320,6 +1320,14 @@ class WebService implements JsonI {
                 $options[ParamOption::FILTER] = $param->filter;
             }
 
+            if (!empty($param->allowedValues)) {
+                $options[ParamOption::ALLOWED_VALUES] = $param->allowedValues;
+            }
+
+            if ($param->pattern !== null) {
+                $options[ParamOption::PATTERN] = $param->pattern;
+            }
+
             $this->addParameters([
                 $param->name => $options
             ]);

--- a/examples/01-core/06-allowed-values-and-pattern/OrderService.php
+++ b/examples/01-core/06-allowed-values-and-pattern/OrderService.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once '../../../vendor/autoload.php';
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\WebService;
+
+/**
+ * Service demonstrating allowed-values and pattern validation.
+ */
+#[RestController('orders', 'Order management with enum and pattern validation')]
+class OrderService extends WebService {
+
+    /**
+     * Get orders filtered by status.
+     * The status parameter only accepts specific values.
+     */
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('status', ParamType::STRING, allowedValues: ['pending', 'shipped', 'delivered', 'cancelled'])]
+    #[RequestParam('sort', ParamType::STRING, true, 'date', allowedValues: ['date', 'total', 'status'])]
+    public function getOrders(string $status, string $sort = 'date'): array {
+        return [
+            'filters' => [
+                'status' => $status,
+                'sort' => $sort,
+            ],
+            'orders' => [
+                ['id' => 1, 'status' => $status, 'total' => 29.99],
+                ['id' => 2, 'status' => $status, 'total' => 59.99],
+            ]
+        ];
+    }
+
+    /**
+     * Create a new order.
+     * Phone must match international format, postal code must be 5 digits.
+     */
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('customer_name', ParamType::STRING)]
+    #[RequestParam('phone', ParamType::STRING, pattern: '/^\+[0-9]{10,15}$/')]
+    #[RequestParam('postal_code', ParamType::STRING, pattern: '/^[0-9]{5}$/')]
+    #[RequestParam('country', ParamType::STRING, allowedValues: ['US', 'CA', 'UK', 'DE', 'FR'])]
+    public function createOrder(string $name, string $phone, string $postalCode, string $country): array {
+        return [
+            'message' => 'Order created',
+            'customer' => [
+                'name' => $name,
+                'phone' => $phone,
+                'postal_code' => $postalCode,
+                'country' => $country,
+            ]
+        ];
+    }
+
+    public function isAuthorized(): bool {
+        return true;
+    }
+
+    public function processRequest() {
+    }
+}

--- a/examples/01-core/06-allowed-values-and-pattern/README.md
+++ b/examples/01-core/06-allowed-values-and-pattern/README.md
@@ -1,0 +1,108 @@
+# Allowed Values and Pattern Validation
+
+Demonstrates restricting parameter values using `allowedValues` (enum) and `pattern` (regex) constraints.
+
+## What This Example Demonstrates
+
+- Restricting a parameter to a set of allowed values (enum validation)
+- Validating parameter format using regex patterns
+- Combining both constraints on different parameters
+- Using these features with `#[RequestParam]` attributes
+
+## Files
+
+- [`OrderService.php`](OrderService.php) - Service with allowed-values and pattern validation
+- [`index.php`](index.php) - Main application entry point
+
+## How to Run
+
+```bash
+php -S localhost:8080
+```
+
+## Testing
+
+```bash
+# Valid status (must be one of: pending, shipped, delivered, cancelled)
+curl "http://localhost:8080?service=orders&status=pending"
+
+# Invalid status — returns validation error
+curl "http://localhost:8080?service=orders&status=unknown"
+
+# Valid sort parameter (optional, defaults to 'date')
+curl "http://localhost:8080?service=orders&status=shipped&sort=total"
+
+# Create order with valid phone (+international format) and postal code (5 digits)
+curl -X POST http://localhost:8080 \
+  -d "service=orders&customer_name=John&phone=%2B12025551234&postal_code=90210&country=US"
+
+# Invalid phone format — returns validation error
+curl -X POST http://localhost:8080 \
+  -d "service=orders&customer_name=John&phone=123&postal_code=90210&country=US"
+
+# Invalid postal code — returns validation error
+curl -X POST http://localhost:8080 \
+  -d "service=orders&customer_name=John&phone=%2B12025551234&postal_code=ABC&country=US"
+
+# Invalid country — returns validation error
+curl -X POST http://localhost:8080 \
+  -d "service=orders&customer_name=John&phone=%2B12025551234&postal_code=90210&country=JP"
+```
+
+## Code Explanation
+
+### Allowed Values (Enum)
+
+Restrict a parameter to a predefined set of values:
+
+```php
+#[RequestParam('status', ParamType::STRING, allowedValues: ['pending', 'shipped', 'delivered', 'cancelled'])]
+```
+
+If the value is not in the set, it is treated as invalid.
+
+### Pattern (Regex)
+
+Validate a parameter against a regular expression:
+
+```php
+#[RequestParam('phone', ParamType::STRING, pattern: '/^\+[0-9]{10,15}$/')]
+#[RequestParam('postal_code', ParamType::STRING, pattern: '/^[0-9]{5}$/')]
+```
+
+If the value does not match the pattern, it is treated as invalid.
+
+### Traditional Approach
+
+These options also work with the array-based parameter definition:
+
+```php
+$this->addParameters([
+    'status' => [
+        ParamOption::TYPE => ParamType::STRING,
+        ParamOption::ALLOWED_VALUES => ['pending', 'shipped', 'delivered', 'cancelled']
+    ],
+    'phone' => [
+        ParamOption::TYPE => ParamType::STRING,
+        ParamOption::PATTERN => '/^\+[0-9]{10,15}$/'
+    ]
+]);
+```
+
+### OpenAPI
+
+Both constraints are automatically included in the generated OpenAPI spec:
+
+```json
+{
+  "type": "string",
+  "enum": ["pending", "shipped", "delivered", "cancelled"]
+}
+```
+
+```json
+{
+  "type": "string",
+  "pattern": "^\\+[0-9]{10,15}$"
+}
+```

--- a/examples/01-core/06-allowed-values-and-pattern/index.php
+++ b/examples/01-core/06-allowed-values-and-pattern/index.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once '../../../vendor/autoload.php';
+require_once 'OrderService.php';
+
+use WebFiori\Http\WebServicesManager;
+
+$manager = new WebServicesManager();
+$manager->addService(new OrderService());
+$manager->process();

--- a/tests/WebFiori/Tests/Http/AllowedValuesAndPatternTest.php
+++ b/tests/WebFiori/Tests/Http/AllowedValuesAndPatternTest.php
@@ -1,0 +1,441 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APIFilter;
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\OpenAPI\Schema;
+use WebFiori\Http\ParamOption;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\Request;
+use WebFiori\Http\RequestParameter;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\AllowedValuesPatternService;
+
+/**
+ * Tests for allowed-values and pattern validation on RequestParameter.
+ * 
+ * Covers: RequestParameter, APIFilter, RequestParam attribute, OpenAPI Schema.
+ * 
+ * @see https://github.com/WebFiori/http/issues/114
+ */
+class AllowedValuesAndPatternTest extends APITestCase {
+
+    // =========================================================================
+    // RequestParameter unit tests
+    // =========================================================================
+
+    public function testSetAllowedValues() {
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive']);
+        $this->assertEquals(['active', 'inactive'], $param->getAllowedValues());
+    }
+
+    public function testGetAllowedValuesDefaultEmpty() {
+        $param = new RequestParameter('name', ParamType::STRING);
+        $this->assertEquals([], $param->getAllowedValues());
+    }
+
+    public function testSetPatternValid() {
+        $param = new RequestParameter('phone', ParamType::STRING);
+        $this->assertTrue($param->setPattern('/^\+[0-9]+$/'));
+        $this->assertEquals('/^\+[0-9]+$/', $param->getPattern());
+    }
+
+    public function testSetPatternInvalid() {
+        $param = new RequestParameter('phone', ParamType::STRING);
+        $this->assertFalse($param->setPattern('/invalid[/'));
+        $this->assertNull($param->getPattern());
+    }
+
+    public function testGetPatternDefaultNull() {
+        $param = new RequestParameter('name', ParamType::STRING);
+        $this->assertNull($param->getPattern());
+    }
+
+    public function testCreateWithAllowedValues() {
+        $param = RequestParameter::create([
+            ParamOption::NAME => 'color',
+            ParamOption::TYPE => ParamType::STRING,
+            ParamOption::ALLOWED_VALUES => ['red', 'green', 'blue']
+        ]);
+        $this->assertEquals(['red', 'green', 'blue'], $param->getAllowedValues());
+    }
+
+    public function testCreateWithPattern() {
+        $param = RequestParameter::create([
+            ParamOption::NAME => 'zip',
+            ParamOption::TYPE => ParamType::STRING,
+            ParamOption::PATTERN => '/^[0-9]{5}$/'
+        ]);
+        $this->assertEquals('/^[0-9]{5}$/', $param->getPattern());
+    }
+
+    // =========================================================================
+    // APIFilter — allowed-values (GET/form-encoded)
+    // =========================================================================
+
+    public function testAllowedValuesAccepted() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive', 'pending']);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['status' => 'active'];
+        $filter->filterGET();
+        $this->assertEquals('active', $filter->getInputs()['status']);
+    }
+
+    public function testAllowedValuesRejected() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive', 'pending']);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['status' => 'deleted'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['status']);
+    }
+
+    public function testAllowedValuesOnIntParam() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('priority', ParamType::INT);
+        $param->setAllowedValues([1, 2, 3]);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['priority' => '2'];
+        $filter->filterGET();
+        $this->assertEquals(2, $filter->getInputs()['priority']);
+    }
+
+    public function testAllowedValuesOnIntParamRejected() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('priority', ParamType::INT);
+        $param->setAllowedValues([1, 2, 3]);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['priority' => '5'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['priority']);
+    }
+
+    public function testAllowedValuesEmptyArrayNoRestriction() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('name', ParamType::STRING);
+        $param->setAllowedValues([]);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['name' => 'anything'];
+        $filter->filterGET();
+        $this->assertEquals('anything', $filter->getInputs()['name']);
+    }
+
+    // =========================================================================
+    // APIFilter — pattern (GET/form-encoded)
+    // =========================================================================
+
+    public function testPatternAccepted() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('zip', ParamType::STRING);
+        $param->setPattern('/^[0-9]{5}$/');
+        $filter->addRequestParameter($param);
+
+        $_GET = ['zip' => '12345'];
+        $filter->filterGET();
+        $this->assertEquals('12345', $filter->getInputs()['zip']);
+    }
+
+    public function testPatternRejected() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('zip', ParamType::STRING);
+        $param->setPattern('/^[0-9]{5}$/');
+        $filter->addRequestParameter($param);
+
+        $_GET = ['zip' => 'abcde'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['zip']);
+    }
+
+    public function testPatternPartialMatchRejected() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('code', ParamType::STRING);
+        $param->setPattern('/^[A-Z]{3}$/');
+        $filter->addRequestParameter($param);
+
+        $_GET = ['code' => 'AB'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['code']);
+    }
+
+    public function testPatternWithNoPatternSetPasses() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('name', ParamType::STRING);
+        $filter->addRequestParameter($param);
+
+        $_GET = ['name' => 'anything goes'];
+        $filter->filterGET();
+        $this->assertEquals('anything goes', $filter->getInputs()['name']);
+    }
+
+    // =========================================================================
+    // APIFilter — both constraints together
+    // =========================================================================
+
+    public function testBothAllowedValuesAndPatternPass() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('code', ParamType::STRING);
+        $param->setAllowedValues(['ABC', 'DEF', 'GHI']);
+        $param->setPattern('/^[A-Z]{3}$/');
+        $filter->addRequestParameter($param);
+
+        $_GET = ['code' => 'ABC'];
+        $filter->filterGET();
+        $this->assertEquals('ABC', $filter->getInputs()['code']);
+    }
+
+    public function testAllowedValuesPassButPatternFails() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('code', ParamType::STRING);
+        $param->setAllowedValues(['abc', 'def']);
+        $param->setPattern('/^[A-Z]{3}$/');
+        $filter->addRequestParameter($param);
+
+        // 'abc' is in allowed values but doesn't match uppercase pattern
+        $_GET = ['code' => 'abc'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['code']);
+    }
+
+    public function testPatternPassesButNotInAllowedValues() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('code', ParamType::STRING);
+        $param->setAllowedValues(['ABC', 'DEF']);
+        $param->setPattern('/^[A-Z]{3}$/');
+        $filter->addRequestParameter($param);
+
+        // 'GHI' matches pattern but not in allowed values
+        $_GET = ['code' => 'GHI'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['code']);
+    }
+
+    // =========================================================================
+    // APIFilter — JSON body path
+    // =========================================================================
+
+    public function testAllowedValuesWithJsonBody() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive']);
+        $filter->addRequestParameter($param);
+
+        $jsonFile = sys_get_temp_dir() . '/allowed_values_test.json';
+        file_put_contents($jsonFile, json_encode(['status' => 'active']));
+
+        $filter->setInputStream($jsonFile);
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $filter->filterPOST();
+
+        $inputs = $filter->getInputs();
+        $this->assertEquals('active', $inputs->get('status'));
+        @unlink($jsonFile);
+    }
+
+    public function testAllowedValuesRejectedWithJsonBody() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive']);
+        $filter->addRequestParameter($param);
+
+        $jsonFile = sys_get_temp_dir() . '/allowed_values_test2.json';
+        file_put_contents($jsonFile, json_encode(['status' => 'deleted']));
+
+        $filter->setInputStream($jsonFile);
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $filter->filterPOST();
+
+        $inputs = $filter->getInputs();
+        $this->assertNull($inputs->get('status'));
+        @unlink($jsonFile);
+    }
+
+    public function testPatternWithJsonBody() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('phone', ParamType::STRING);
+        $param->setPattern('/^\+[0-9]{10,15}$/');
+        $filter->addRequestParameter($param);
+
+        $jsonFile = sys_get_temp_dir() . '/pattern_test.json';
+        file_put_contents($jsonFile, json_encode(['phone' => '+1234567890123']));
+
+        $filter->setInputStream($jsonFile);
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $filter->filterPOST();
+
+        $inputs = $filter->getInputs();
+        $this->assertEquals('+1234567890123', $inputs->get('phone'));
+        @unlink($jsonFile);
+    }
+
+    public function testPatternRejectedWithJsonBody() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('phone', ParamType::STRING);
+        $param->setPattern('/^\+[0-9]{10,15}$/');
+        $filter->addRequestParameter($param);
+
+        $jsonFile = sys_get_temp_dir() . '/pattern_test2.json';
+        file_put_contents($jsonFile, json_encode(['phone' => 'not-a-phone']));
+
+        $filter->setInputStream($jsonFile);
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $filter->filterPOST();
+
+        $inputs = $filter->getInputs();
+        $this->assertNull($inputs->get('phone'));
+        @unlink($jsonFile);
+    }
+
+    // =========================================================================
+    // Attribute-based service integration tests
+    // =========================================================================
+
+    public function testAllowedValuesViaAttribute() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AllowedValuesPatternService());
+
+        $output = $this->getRequest($manager, 'allowed-values-pattern-service', [
+            'status' => 'active',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('active', $response['status']);
+    }
+
+    public function testAllowedValuesViaAttributeRejected() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AllowedValuesPatternService());
+
+        $output = $this->getRequest($manager, 'allowed-values-pattern-service', [
+            'status' => 'deleted',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    public function testPatternViaAttribute() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AllowedValuesPatternService());
+
+        $output = $this->postRequest($manager, 'allowed-values-pattern-service', [
+            'phone' => '%2B1234567890123',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('+1234567890123', $response['phone']);
+    }
+
+    public function testPatternViaAttributeRejected() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AllowedValuesPatternService());
+
+        $output = $this->postRequest($manager, 'allowed-values-pattern-service', [
+            'phone' => 'invalid',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    // =========================================================================
+    // OpenAPI Schema tests
+    // =========================================================================
+
+    public function testSchemaWithAllowedValues() {
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive', 'pending']);
+
+        $schema = Schema::fromRequestParameter($param);
+        $json = $schema->toJSON();
+
+        $this->assertEquals(['active', 'inactive', 'pending'], $json->get('enum'));
+    }
+
+    public function testSchemaWithPattern() {
+        $param = new RequestParameter('zip', ParamType::STRING);
+        $param->setPattern('/^[0-9]{5}$/');
+
+        $schema = Schema::fromRequestParameter($param);
+        $json = $schema->toJSON();
+
+        // Pattern should be without PHP delimiters
+        $this->assertEquals('^[0-9]{5}$', $json->get('pattern'));
+    }
+
+    public function testSchemaWithBothConstraints() {
+        $param = new RequestParameter('code', ParamType::STRING);
+        $param->setAllowedValues(['ABC', 'DEF']);
+        $param->setPattern('/^[A-Z]{3}$/');
+
+        $schema = Schema::fromRequestParameter($param);
+        $json = $schema->toJSON();
+
+        $this->assertEquals(['ABC', 'DEF'], $json->get('enum'));
+        $this->assertEquals('^[A-Z]{3}$', $json->get('pattern'));
+    }
+
+    public function testSchemaWithoutConstraintsHasNoEnumOrPattern() {
+        $param = new RequestParameter('name', ParamType::STRING);
+
+        $schema = Schema::fromRequestParameter($param);
+        $json = $schema->toJSON();
+
+        $this->assertFalse($json->hasKey('enum'));
+        $this->assertFalse($json->hasKey('pattern'));
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    public function testAllowedValuesWithDefaultFallback() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('status', ParamType::STRING);
+        $param->setAllowedValues(['active', 'inactive']);
+        $param->setIsOptional(true);
+        $param->setDefault('active');
+        $filter->addRequestParameter($param);
+
+        // Value not in allowed set, but has default
+        $_GET = ['status' => 'deleted'];
+        $filter->filterGET();
+        // Should fall back to default since INVALID + default = default
+        $this->assertEquals('active', $filter->getInputs()['status']);
+    }
+
+    public function testPatternOnEmailType() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('email', ParamType::EMAIL);
+        $param->setPattern('/@company\.com$/');
+        $filter->addRequestParameter($param);
+
+        // Valid email but wrong domain
+        $_GET = ['email' => 'user@other.com'];
+        $filter->filterGET();
+        $this->assertEquals(APIFilter::INVALID, $filter->getInputs()['email']);
+    }
+
+    public function testPatternOnEmailTypeAccepted() {
+        $filter = new APIFilter();
+        $param = new RequestParameter('email', ParamType::EMAIL);
+        $param->setPattern('/@company\.com$/');
+        $filter->addRequestParameter($param);
+
+        $_GET = ['email' => 'user@company.com'];
+        $filter->filterGET();
+        $this->assertEquals('user@company.com', $filter->getInputs()['email']);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/AllowedValuesPatternService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/AllowedValuesPatternService.php
@@ -1,0 +1,43 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+
+#[RestController('allowed-values-pattern-service')]
+class AllowedValuesPatternService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('status', ParamType::STRING, allowedValues: ['active', 'inactive', 'pending'])]
+    public function getByStatus(string $status): Json {
+        $json = new Json();
+        $json->add('status', $status);
+        return $json;
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('phone', ParamType::STRING, pattern: '/^\+[0-9]{10,15}$/')]
+    public function createWithPhone(string $phone): Json {
+        $json = new Json();
+        $json->add('phone', $phone);
+        return $json;
+    }
+
+    public function isAuthorized(): bool {
+        return true;
+    }
+
+    public function processRequest() {
+    }
+}


### PR DESCRIPTION
# Summary
Add `allowed-values` (enum) and `pattern` (regex) validation options to `RequestParameter`, with full support in attributes, APIFilter, and OpenAPI generation.

## Motivation
Two common validation needs currently require writing custom filter functions when they should be built-in. `UriParameter` already has `allowed-values` but `RequestParameter` does not. Fixes #114.

## Changes
- Added `ParamOption::ALLOWED_VALUES` and `ParamOption::PATTERN` constants
- Added `allowedValues`/`pattern` properties with getters and setters to `RequestParameter`
- Added `allowedValues`/`pattern` params to `#[RequestParam]` attribute
- Wired attribute properties in `WebService::configureParametersFromMethod()`
- Added `checkAllowedAndPattern()` in `APIFilter` for both form-encoded and JSON paths
- OpenAPI `Schema::fromRequestParameter()` now generates `enum` and `pattern` fields

## UI Changes
N/A

## How to Test / Verify
```bash
composer test
# or specifically:
php vendor/bin/phpunit tests/WebFiori/Tests/Http/AllowedValuesAndPatternTest.php
```

34 new tests, 42 assertions. Full suite: 491 tests pass.

## Breaking Changes and Migration Steps
None. Purely additive — existing parameters without these options behave identically.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #114