### PR TITLE
feat(#111): allow isAuthorized() to return string as denial reason

### DIFF
--- a/WebFiori/Http/WebService.php
+++ b/WebFiori/Http/WebService.php
@@ -664,7 +664,7 @@ class WebService implements JsonI {
      * @return bool True if the user is allowed to perform the action. False otherwise.
      * 
      */
-    public function isAuthorized() : bool {
+    public function isAuthorized() : string|bool {
         return false;
     }
     /**

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -497,8 +497,9 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 401 - Not Authorized.
      * 
      */
-    public function notAuth() {
-        $this->sendResponse(ResponseMessage::get('401'), 401, WebService::E);
+    public function notAuth(?string $message = null) {
+        $msg = $message !== null ? $message : ResponseMessage::get('401');
+        $this->sendResponse($msg, 401, WebService::E);
     }
 
     /**
@@ -929,10 +930,13 @@ class WebServicesManager implements JsonI {
             $service = $this->getServiceByName($this->getCalledServiceName());
 
 
-            if ($this->isAuth($service)) {
+            $authResult = $this->isAuth($service);
+
+            if ($authResult === true) {
                 $this->processService($service);
             } else {
-                $this->notAuth();
+                $reason = is_string($authResult) ? $authResult : null;
+                $this->notAuth($reason);
             }
         } else if (count($this->missingParamsArr) != 0) {
             $this->missingParams();
@@ -1137,12 +1141,9 @@ class WebServicesManager implements JsonI {
         return $retVal;
     }
     private function isAuth(WebService $service) {
-        $isAuth = false;
-
         if ($service->isAuthRequired()) {
             // Check if method has authorization annotations
             if ($service->hasMethodAuthorizationAnnotations()) {
-                // Use annotation-based authorization
                 return $service->checkMethodAuthorization();
             }
 
@@ -1150,10 +1151,21 @@ class WebServicesManager implements JsonI {
             $isAuthCheck = 'isAuthorized'.$this->getRequest()->getMethod();
 
             if (!method_exists($service, $isAuthCheck)) {
-                return $service->isAuthorized() === null || $service->isAuthorized();
+                $result = $service->isAuthorized();
+            } else {
+                $result = $service->$isAuthCheck();
             }
 
-            return $service->$isAuthCheck() === null || $service->$isAuthCheck();
+            if ($result === true || $result === null) {
+                return true;
+            }
+
+            // String means not authorized with a custom reason
+            if (is_string($result)) {
+                return $result;
+            }
+
+            return false;
         }
 
         return true;

--- a/tests/WebFiori/Tests/Http/IsAuthorizedStringTest.php
+++ b/tests/WebFiori/Tests/Http/IsAuthorizedStringTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\StringAuthDenialService;
+
+/**
+ * Tests for isAuthorized() returning string as denial reason.
+ * 
+ * @see https://github.com/WebFiori/http/issues/111
+ */
+class IsAuthorizedStringTest extends APITestCase {
+
+    /**
+     * Test that returning a string from isAuthorized() sends it as the 401 message.
+     */
+    public function testStringDenialReason() {
+        $manager = new WebServicesManager();
+        $manager->addService(new StringAuthDenialService());
+
+        $output = $this->getRequest($manager, 'string-auth-denial');
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+        $this->assertEquals('You must be a premium member to access this resource.', $response['message']);
+    }
+
+    /**
+     * Test that returning false still uses the default 401 message.
+     */
+    public function testBoolFalseDenialUsesDefault() {
+        $service = new class extends \WebFiori\Http\WebService {
+            public function __construct() {
+                parent::__construct('bool-deny');
+                $this->addRequestMethod('GET');
+            }
+            public function isAuthorized(): bool {
+                return false;
+            }
+            public function processRequest() {
+                $this->sendResponse('Should not reach here', 200, 'success');
+            }
+        };
+
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        $output = $this->getRequest($manager, 'bool-deny');
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+        $this->assertNotEmpty($response['message']);
+    }
+
+    /**
+     * Test that returning true allows the request through.
+     */
+    public function testTrueAllowsAccess() {
+        // Use a service that returns true from isAuthorized
+        $manager = new WebServicesManager();
+        // NoAuthService returns false, but let's use an inline service
+        $service = new class extends \WebFiori\Http\WebService {
+            public function __construct() {
+                parent::__construct('auth-pass-test');
+                $this->addRequestMethod('GET');
+            }
+            public function isAuthorized(): string|bool {
+                return true;
+            }
+            public function processRequest() {
+                $this->sendResponse('Access granted', 200, 'success');
+            }
+        };
+
+        $manager->addService($service);
+        $output = $this->getRequest($manager, 'auth-pass-test');
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('success', $response['type']);
+        $this->assertEquals('Access granted', $response['message']);
+    }
+
+    /**
+     * Test different denial reasons for different conditions.
+     */
+    public function testMultipleDenialReasons() {
+        $service = new class extends \WebFiori\Http\WebService {
+            public function __construct() {
+                parent::__construct('multi-reason');
+                $this->addRequestMethod('GET');
+            }
+            public function isAuthorized(): string|bool {
+                $token = $this->getAuthHeader();
+                if ($token === null) {
+                    return 'Authentication token is required.';
+                }
+                return 'Insufficient privileges.';
+            }
+            public function processRequest() {
+                $this->sendResponse('OK', 200, 'success');
+            }
+        };
+
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        // No auth header — should get "token required" message
+        $output = $this->getRequest($manager, 'multi-reason');
+        $response = json_decode($output, true);
+        $this->assertEquals('Authentication token is required.', $response['message']);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/StringAuthDenialService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/StringAuthDenialService.php
@@ -1,0 +1,24 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\WebService;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\ResponseBody;
+
+#[RestController('string-auth-denial')]
+class StringAuthDenialService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    public function getData(): array {
+        return ['data' => 'secret'];
+    }
+
+    public function isAuthorized(): string|bool {
+        return 'You must be a premium member to access this resource.';
+    }
+
+    public function processRequest() {
+    }
+}


### PR DESCRIPTION
# Summary
Allow `isAuthorized()` to return a string which is used as the 401 response message, eliminating the need for global `ResponseMessage::set()` calls.

## Motivation
Developers currently must use global `ResponseMessage::set("401", ...)` to customize denial messages, which has issues with global state, set-before-check timing, and multiple failure paths. Fixes #111.

## Changes
- Changed `WebService::isAuthorized()` return type from `bool` to `string|bool`
- Updated `WebServicesManager::isAuth()` to capture and propagate string results
- Updated `notAuth()` to accept an optional custom message parameter
- Added test service and 4 test cases

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/IsAuthorizedStringTest.php
```
Full suite: 465 tests pass.

## Breaking Changes and Migration Steps
None. Existing `bool` returns are fully backward compatible — PHP allows narrower return types in child classes.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #111