### PR TITLE
refactor(#118): move PUT/PATCH body parsing into Request class

### DIFF
--- a/WebFiori/Http/Request.php
+++ b/WebFiori/Http/Request.php
@@ -31,6 +31,12 @@ class Request extends HttpMessage {
         $request->setRequestMethod($request->getMethodFromGlobals());
         $request->setBody(file_get_contents('php://input'));
 
+        $method = $request->getMethod();
+
+        if ($method === RequestMethod::PUT || $method === RequestMethod::PATCH) {
+            $request->parsePutPatchBody();
+        }
+
         return $request;
     }
     /**
@@ -229,6 +235,35 @@ class Request extends HttpMessage {
     public function getUri() : RequestUri {
         return new RequestUri($this->getRequestedURI());
     }
+    /**
+     * Parses PUT/PATCH request bodies into $_POST and $_FILES.
+     * 
+     * PHP only auto-parses POST bodies. For PUT and PATCH, the raw body
+     * must be parsed manually for application/x-www-form-urlencoded and
+     * multipart/form-data content types.
+     */
+    public function parsePutPatchBody() : void {
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+        $input = $this->getBody();
+
+        if (empty($input)) {
+            $input = file_get_contents('php://input');
+        }
+
+        if (empty($input)) {
+            return;
+        }
+
+        if (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
+            parse_str($input, $_POST);
+
+            return;
+        }
+
+        if (strpos($contentType, 'multipart/form-data') === 0) {
+            $this->parseMultipartBody($input, $contentType);
+        }
+    }
 
     private function extractHeaders() {
         $this->getHeadersPool()->clear();
@@ -311,5 +346,57 @@ class Request extends HttpMessage {
         }
 
         return $retVal;
+    }
+
+    private function parseMultipartBody(string $input, string $contentType) : void {
+        preg_match('/boundary=(.+)$/', $contentType, $matches);
+
+        if (!isset($matches[1])) {
+            return;
+        }
+
+        $boundary = '--'.$matches[1];
+        $parts = explode($boundary, $input);
+
+        foreach ($parts as $part) {
+            if (trim($part) === '' || trim($part) === '--') {
+                continue;
+            }
+
+            $sections = explode("\r\n\r\n", $part, 2);
+
+            if (count($sections) !== 2) {
+                continue;
+            }
+
+            $headers = $sections[0];
+            $content = rtrim($sections[1], "\r\n");
+
+            if (preg_match('/name="([^"]+)"/', $headers, $nameMatch)) {
+                $fieldName = $nameMatch[1];
+
+                if (preg_match('/filename="([^"]*)"/', $headers, $fileMatch)) {
+                    $filename = $fileMatch[1];
+                    $fileType = 'application/octet-stream';
+
+                    if (preg_match('/Content-Type:\s*(.+)/i', $headers, $typeMatch)) {
+                        $fileType = trim($typeMatch[1]);
+                    }
+
+                    $tmpFile = tempnam(sys_get_temp_dir(), 'put_upload_');
+                    file_put_contents($tmpFile, $content);
+
+                    $_FILES[$fieldName] = [
+                        'name' => $filename,
+                        'type' => $fileType,
+                        'tmp_name' => $tmpFile,
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => strlen($content)
+                    ];
+                } else {
+                    $_POST[$fieldName] = $content;
+                }
+            }
+        }
     }
 }

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -1068,10 +1068,6 @@ class WebServicesManager implements JsonI {
         } else if ($reqMeth == RequestMethod::POST || 
                    $reqMeth == RequestMethod::PUT || 
                    $reqMeth == RequestMethod::PATCH) {
-            // Populate PUT/PATCH data before filtering
-            if ($reqMeth == RequestMethod::PUT || $reqMeth == RequestMethod::PATCH) {
-                $this->populatePutData($contentType);
-            }
             $this->filter->filterPOST();
         }
     }
@@ -1130,8 +1126,6 @@ class WebServicesManager implements JsonI {
             } else if ($reqMeth == RequestMethod::POST && isset($_POST[$serviceNameIndex])) {
                 $retVal = filter_var($_POST[$serviceNameIndex]);
             } else if ($reqMeth == RequestMethod::PUT || $reqMeth == RequestMethod::PATCH) {
-                $this->populatePutData($contentType);
-
                 if (isset($_POST[$serviceNameIndex])) {
                     $retVal = filter_var($_POST[$serviceNameIndex]);
                 }
@@ -1170,82 +1164,11 @@ class WebServicesManager implements JsonI {
 
         return true;
     }
+    /**
+     * @deprecated Since 5.1.0. PUT/PATCH body parsing is now handled by Request::parsePutPatchBody().
+     */
     private function populatePutData(string $contentType) {
-        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
-        $input = file_get_contents('php://input');
-
-        if (empty($input)) {
-            return;
-        }
-
-        // Handle application/x-www-form-urlencoded
-        if (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
-            parse_str($input, $_POST);
-
-            return;
-        }
-
-        // Handle multipart/form-data
-        if (strpos($contentType, 'multipart/form-data') === 0) {
-            // Extract boundary from content type
-            preg_match('/boundary=(.+)$/', $contentType, $matches);
-
-            if (!isset($matches[1])) {
-                return;
-            }
-
-            $boundary = '--'.$matches[1];
-            $parts = explode($boundary, $input);
-
-            foreach ($parts as $part) {
-                if (trim($part) === '' || trim($part) === '--') {
-                    continue;
-                }
-
-                // Split headers and content
-                $sections = explode("\r\n\r\n", $part, 2);
-
-                if (count($sections) !== 2) {
-                    continue;
-                }
-
-                $headers = $sections[0];
-                $content = rtrim($sections[1], "\r\n");
-
-                // Parse Content-Disposition header
-                if (preg_match('/name="([^"]+)"/', $headers, $nameMatch)) {
-                    $fieldName = $nameMatch[1];
-
-                    // Check if it's a file upload
-                    if (preg_match('/filename="([^"]*)"/', $headers, $fileMatch)) {
-                        // Handle file upload
-                        $filename = $fileMatch[1];
-
-                        // Extract content type if present
-                        $fileType = 'application/octet-stream';
-
-                        if (preg_match('/Content-Type:\s*(.+)/i', $headers, $typeMatch)) {
-                            $fileType = trim($typeMatch[1]);
-                        }
-
-                        // Create temporary file
-                        $tmpFile = tempnam(sys_get_temp_dir(), 'put_upload_');
-                        file_put_contents($tmpFile, $content);
-
-                        $_FILES[$fieldName] = [
-                            'name' => $filename,
-                            'type' => $fileType,
-                            'tmp_name' => $tmpFile,
-                            'error' => UPLOAD_ERR_OK,
-                            'size' => strlen($content)
-                        ];
-                    } else {
-                        // Regular form field
-                        $_POST[$fieldName] = $content;
-                    }
-                }
-            }
-        }
+        // No-op: body parsing is now done in Request::createFromGlobals()
     }
     private function processService(WebService $service) {
         // Try auto-processing only if service has ResponseBody methods

--- a/tests/WebFiori/Tests/Http/RequestPutPatchParsingTest.php
+++ b/tests/WebFiori/Tests/Http/RequestPutPatchParsingTest.php
@@ -1,0 +1,167 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Http\Request;
+use WebFiori\Http\RequestMethod;
+
+/**
+ * Tests for Request::parsePutPatchBody().
+ * 
+ * Verifies that PUT/PATCH body parsing (previously in WebServicesManager::populatePutData)
+ * now works correctly in the Request class.
+ * 
+ * @see https://github.com/WebFiori/http/issues/118
+ */
+class RequestPutPatchParsingTest extends TestCase {
+
+    private array $globalsBackup;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->globalsBackup = [
+            'POST' => $_POST,
+            'FILES' => $_FILES,
+            'SERVER' => $_SERVER,
+        ];
+    }
+
+    protected function tearDown(): void {
+        $_POST = $this->globalsBackup['POST'];
+        $_FILES = $this->globalsBackup['FILES'];
+        $_SERVER = $this->globalsBackup['SERVER'];
+        parent::tearDown();
+    }
+
+    public function testParseUrlEncodedPutBody() {
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody('name=John&age=30&email=john%40example.com');
+
+        $request->parsePutPatchBody();
+
+        $this->assertEquals('John', $_POST['name']);
+        $this->assertEquals('30', $_POST['age']);
+        $this->assertEquals('john@example.com', $_POST['email']);
+    }
+
+    public function testParseUrlEncodedPatchBody() {
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PATCH);
+        $request->setBody('status=active&priority=high');
+
+        $request->parsePutPatchBody();
+
+        $this->assertEquals('active', $_POST['status']);
+        $this->assertEquals('high', $_POST['priority']);
+    }
+
+    public function testParseMultipartPutBody() {
+        $_POST = [];
+        $_FILES = [];
+        $boundary = '----WebKitFormBoundary7MA4YWxkTrZu0gW';
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data; boundary=' . $boundary;
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $body = "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n"
+            . "Content-Disposition: form-data; name=\"title\"\r\n\r\n"
+            . "My Document\r\n"
+            . "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n"
+            . "Content-Disposition: form-data; name=\"description\"\r\n\r\n"
+            . "A test document\r\n"
+            . "------WebKitFormBoundary7MA4YWxkTrZu0gW--\r\n";
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody($body);
+
+        $request->parsePutPatchBody();
+
+        $this->assertEquals('My Document', $_POST['title']);
+        $this->assertEquals('A test document', $_POST['description']);
+    }
+
+    public function testParseMultipartWithFileUpload() {
+        $_POST = [];
+        $_FILES = [];
+        $boundary = '----TestBoundary123';
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data; boundary=' . $boundary;
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $fileContent = 'Hello, this is file content.';
+        $body = "------TestBoundary123\r\n"
+            . "Content-Disposition: form-data; name=\"name\"\r\n\r\n"
+            . "John\r\n"
+            . "------TestBoundary123\r\n"
+            . "Content-Disposition: form-data; name=\"avatar\"; filename=\"photo.png\"\r\n"
+            . "Content-Type: image/png\r\n\r\n"
+            . $fileContent . "\r\n"
+            . "------TestBoundary123--\r\n";
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody($body);
+
+        $request->parsePutPatchBody();
+
+        $this->assertEquals('John', $_POST['name']);
+        $this->assertArrayHasKey('avatar', $_FILES);
+        $this->assertEquals('photo.png', $_FILES['avatar']['name']);
+        $this->assertEquals('image/png', $_FILES['avatar']['type']);
+        $this->assertEquals(UPLOAD_ERR_OK, $_FILES['avatar']['error']);
+        $this->assertEquals(strlen($fileContent), $_FILES['avatar']['size']);
+        $this->assertFileExists($_FILES['avatar']['tmp_name']);
+        $this->assertEquals($fileContent, file_get_contents($_FILES['avatar']['tmp_name']));
+
+        // Cleanup temp file
+        @unlink($_FILES['avatar']['tmp_name']);
+    }
+
+    public function testEmptyBodyDoesNothing() {
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody('');
+
+        $request->parsePutPatchBody();
+
+        $this->assertEmpty($_POST);
+    }
+
+    public function testJsonContentTypeNotParsed() {
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody('{"name":"John"}');
+
+        $request->parsePutPatchBody();
+
+        // JSON bodies are handled by APIFilter, not here
+        $this->assertEmpty($_POST);
+    }
+
+    public function testMultipartWithoutBoundaryDoesNothing() {
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
+
+        $request = new Request();
+        $request->setRequestMethod(RequestMethod::PUT);
+        $request->setBody('some data');
+
+        $request->parsePutPatchBody();
+
+        $this->assertEmpty($_POST);
+    }
+}


### PR DESCRIPTION
# Summary
Move PUT/PATCH body parsing logic from `WebServicesManager::populatePutData()` into `Request::parsePutPatchBody()`. Step 1 of 5 in ADR-0005 (RequestProcessor refactor).

## Motivation
`WebServicesManager` manually parses PUT/PATCH multipart bodies in a private method. This logic belongs in the `Request` class — it should parse its own body regardless of HTTP method. Fixes #118.

## Changes
- Added `Request::parsePutPatchBody()` — parses `application/x-www-form-urlencoded` and `multipart/form-data` bodies into `$_POST` and `$_FILES`
- Added private `Request::parseMultipartBody()` helper
- `Request::createFromGlobals()` now calls `parsePutPatchBody()` automatically for PUT/PATCH
- Removed `populatePutData()` calls from `WebServicesManager`
- Deprecated `WebServicesManager::populatePutData()` as a no-op stub

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/RequestPutPatchParsingTest.php
```
7 new tests, 18 assertions. Full suite: 506 tests pass.

## Breaking Changes and Migration Steps
None. `WebServicesManager` still works — body parsing now happens earlier (in `Request::createFromGlobals()`). Anyone calling `populatePutData()` directly (unlikely — it was private) gets a no-op.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #118
Part of ADR-0005: https://github.com/WebFiori/docs/blob/main/adr/0005-request-processor-replaces-manager.md