### PR TITLE
refactor(#119): extract ErrorResponse helper class

### DIFF
--- a/WebFiori/Http/ErrorResponse.php
+++ b/WebFiori/Http/ErrorResponse.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2019-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http;
+
+use WebFiori\Json\Json;
+
+/**
+ * A helper class for generating standardized JSON error responses.
+ * 
+ * Each method returns a Json object containing the error response body
+ * along with the appropriate HTTP status code.
+ *
+ * @author Ibrahim
+ */
+class ErrorResponse {
+    /**
+     * Generates a 415 content type not supported response.
+     * 
+     * @param string $type The unsupported content type.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function contentTypeNotSupported(string $type = '') : array {
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('415'));
+        $json->add('type', WebService::E);
+        $json->add('http-code', 415);
+
+        if (!empty($type)) {
+            $json->add('more-info', new Json(['request-content-type' => $type]));
+        }
+
+        return ['json' => $json, 'code' => 415];
+    }
+    /**
+     * Generates a response for invalid parameters.
+     * 
+     * @param array $params Array of parameter names that have invalid values.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function invalidParams(array $params) : array {
+        $val = self::formatParamNames($params);
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('404-1').$val.'.');
+        $json->add('type', WebService::E);
+        $json->add('http-code', 404);
+        $json->add('more-info', new Json(['invalid' => $params]));
+
+        return ['json' => $json, 'code' => 404];
+    }
+    /**
+     * Generates a 405 method not allowed response.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function methodNotAllowed() : array {
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('405'));
+        $json->add('type', WebService::E);
+        $json->add('http-code', 405);
+
+        return ['json' => $json, 'code' => 405];
+    }
+    /**
+     * Generates a response for missing required parameters.
+     * 
+     * @param array $params Array of parameter names that are missing.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function missingParams(array $params) : array {
+        $val = self::formatParamNames($params);
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('404-2').$val.'.');
+        $json->add('type', WebService::E);
+        $json->add('http-code', 404);
+        $json->add('more-info', new Json(['missing' => $params]));
+
+        return ['json' => $json, 'code' => 404];
+    }
+    /**
+     * Generates a 404 response for missing service name.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function missingServiceName() : array {
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('404-3'));
+        $json->add('type', WebService::E);
+        $json->add('http-code', 404);
+
+        return ['json' => $json, 'code' => 404];
+    }
+    /**
+     * Generates a 404 response for unsupported service.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function serviceNotFound() : array {
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('404-5'));
+        $json->add('type', WebService::E);
+        $json->add('http-code', 404);
+
+        return ['json' => $json, 'code' => 404];
+    }
+    /**
+     * Generates a 404 response for unimplemented service.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function serviceNotImplemented() : array {
+        $json = new Json();
+        $json->add('message', ResponseMessage::get('404-4'));
+        $json->add('type', WebService::E);
+        $json->add('http-code', 404);
+
+        return ['json' => $json, 'code' => 404];
+    }
+    /**
+     * Generates a 401 unauthorized response.
+     * 
+     * @param string|null $message Custom denial message. If null, uses default.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function unauthorized(?string $message = null) : array {
+        $msg = $message !== null ? $message : ResponseMessage::get('401');
+        $json = new Json();
+        $json->add('message', $msg);
+        $json->add('type', WebService::E);
+        $json->add('http-code', 401);
+
+        return ['json' => $json, 'code' => 401];
+    }
+    /**
+     * Formats an array of parameter names into a comma-separated quoted string.
+     */
+    private static function formatParamNames(array $params) : string {
+        $val = '';
+        $count = count($params);
+        $i = 0;
+
+        foreach ($params as $paramName) {
+            if ($i + 1 == $count) {
+                $val .= '\''.$paramName.'\'';
+            } else {
+                $val .= '\''.$paramName.'\', ';
+            }
+            $i++;
+        }
+
+        return $val;
+    }
+}

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -213,10 +213,12 @@ class WebServicesManager implements JsonI {
      * request header.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::contentTypeNotSupported() instead.
+     */
     public function contentTypeNotSupported(string $cType = '') {
-        $j = new Json();
-        $j->add('request-content-type', $cType);
-        $this->sendResponse(ResponseMessage::get('415'), 415, WebService::E, $j);
+        $result = ErrorResponse::contentTypeNotSupported($cType);
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Returns the base path for all services.
@@ -388,23 +390,12 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 404 - Not Found.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::invalidParams() instead.
+     */
     public function invParams() {
-        $val = '';
-        $i = 0;
-        $paramsNamesArr = $this->getInvalidParameters();
-        $count = count($paramsNamesArr);
-
-        foreach ($paramsNamesArr as $paramName) {
-            if ($i + 1 == $count) {
-                $val .= '\''.$paramName.'\'';
-            } else {
-                $val .= '\''.$paramName.'\', ';
-            }
-            $i++;
-        }
-        $this->sendResponse(ResponseMessage::get('404-1').$val.'.', 404, WebService::E, new Json([
-            'invalid' => $paramsNamesArr
-        ]));
+        $result = ErrorResponse::invalidParams($this->getInvalidParameters());
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Checks if request content type is supported by the service or not (For 'POST' 
@@ -448,23 +439,12 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 404 - Not Found.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::missingParams() instead.
+     */
     public function missingParams() {
-        $val = '';
-        $paramsNamesArr = $this->getMissingParameters();
-        $i = 0;
-        $count = count($paramsNamesArr);
-
-        foreach ($paramsNamesArr as $paramName) {
-            if ($i + 1 == $count) {
-                $val .= '\''.$paramName.'\'';
-            } else {
-                $val .= '\''.$paramName.'\', ';
-            }
-            $i++;
-        }
-        $this->sendResponse(ResponseMessage::get('404-2').$val.'.', 404, WebService::E, new Json([
-            'missing' => $paramsNamesArr
-        ]));
+        $result = ErrorResponse::missingParams($this->getMissingParameters());
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Sends a response message to tell the front-end that the parameter 
@@ -480,8 +460,12 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 404 - Not Found.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::missingServiceName() instead.
+     */
     public function missingServiceName() {
-        $this->sendResponse(ResponseMessage::get('404-3'), 404, WebService::E);
+        $result = ErrorResponse::missingServiceName();
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Sends a response message to indicate that a user is not authorized call a 
@@ -497,9 +481,12 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 401 - Not Authorized.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::unauthorized() instead.
+     */
     public function notAuth(?string $message = null) {
-        $msg = $message !== null ? $message : ResponseMessage::get('401');
-        $this->sendResponse($msg, 401, WebService::E);
+        $result = ErrorResponse::unauthorized($message);
+        $this->send('application/json', $result['json'], $result['code']);
     }
 
     /**
@@ -622,8 +609,12 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 405 - Method Not Allowed.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::methodNotAllowed() instead.
+     */
     public function requestMethodNotAllowed() {
-        $this->sendResponse(ResponseMessage::get('405'), 405, WebService::E);
+        $result = ErrorResponse::methodNotAllowed();
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Sends Back a data using specific content type and specific response code.
@@ -730,24 +721,19 @@ class WebServicesManager implements JsonI {
      * In addition to the message, The response will send HTTP code 404 - Not Found.
      * 
      */
+    /**
+     * @deprecated Use ErrorResponse::serviceNotImplemented() instead.
+     */
     public function serviceNotImplemented() {
-        $this->sendResponse(ResponseMessage::get('404-4'), 404, WebService::E);
+        $result = ErrorResponse::serviceNotImplemented();
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
-     * Sends a response message to indicate that called web service is not supported by the API.
-     * 
-     * This method will send back a JSON string in the following format:
-     * <p>
-     * {<br/>
-     * &nbsp;&nbsp;"message":"Action not supported",<br/>
-     * &nbsp;&nbsp;"type":"error"<br/>
-     * }
-     * </p>
-     * In addition to the message, The response will send HTTP code 404 - Not Found.
-     * 
+     * @deprecated Use ErrorResponse::serviceNotFound() instead.
      */
     public function serviceNotSupported() {
-        $this->sendResponse(ResponseMessage::get('404-5'), 404, WebService::E);
+        $result = ErrorResponse::serviceNotFound();
+        $this->send('application/json', $result['json'], $result['code']);
     }
     /**
      * Sets the base path for all services in this manager.

--- a/tests/WebFiori/Tests/Http/ErrorResponseTest.php
+++ b/tests/WebFiori/Tests/Http/ErrorResponseTest.php
@@ -1,0 +1,129 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Http\ErrorResponse;
+
+/**
+ * Unit tests for ErrorResponse helper class.
+ * 
+ * @see https://github.com/WebFiori/http/issues/119
+ */
+class ErrorResponseTest extends TestCase {
+
+    public function testInvalidParams() {
+        $result = ErrorResponse::invalidParams(['email', 'age']);
+
+        $this->assertEquals(404, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(404, $json->get('http-code'));
+        $this->assertStringContainsString('email', $json->get('message'));
+        $this->assertStringContainsString('age', $json->get('message'));
+        $this->assertEquals(['email', 'age'], $json->get('more-info')->get('invalid'));
+    }
+
+    public function testInvalidParamsSingle() {
+        $result = ErrorResponse::invalidParams(['name']);
+
+        $json = $result['json'];
+        $this->assertStringContainsString("'name'", $json->get('message'));
+        $this->assertEquals(['name'], $json->get('more-info')->get('invalid'));
+    }
+
+    public function testMissingParams() {
+        $result = ErrorResponse::missingParams(['username', 'password']);
+
+        $this->assertEquals(404, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(404, $json->get('http-code'));
+        $this->assertStringContainsString('username', $json->get('message'));
+        $this->assertStringContainsString('password', $json->get('message'));
+        $this->assertEquals(['username', 'password'], $json->get('more-info')->get('missing'));
+    }
+
+    public function testMissingParamsSingle() {
+        $result = ErrorResponse::missingParams(['token']);
+
+        $json = $result['json'];
+        $this->assertStringContainsString("'token'", $json->get('message'));
+    }
+
+    public function testUnauthorizedDefault() {
+        $result = ErrorResponse::unauthorized();
+
+        $this->assertEquals(401, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(401, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+    }
+
+    public function testUnauthorizedCustomMessage() {
+        $result = ErrorResponse::unauthorized('You must be a premium member.');
+
+        $json = $result['json'];
+        $this->assertEquals('You must be a premium member.', $json->get('message'));
+        $this->assertEquals(401, $result['code']);
+    }
+
+    public function testMethodNotAllowed() {
+        $result = ErrorResponse::methodNotAllowed();
+
+        $this->assertEquals(405, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(405, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+    }
+
+    public function testServiceNotFound() {
+        $result = ErrorResponse::serviceNotFound();
+
+        $this->assertEquals(404, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(404, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+    }
+
+    public function testServiceNotImplemented() {
+        $result = ErrorResponse::serviceNotImplemented();
+
+        $this->assertEquals(404, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(404, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+    }
+
+    public function testMissingServiceName() {
+        $result = ErrorResponse::missingServiceName();
+
+        $this->assertEquals(404, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(404, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+    }
+
+    public function testContentTypeNotSupported() {
+        $result = ErrorResponse::contentTypeNotSupported('text/xml');
+
+        $this->assertEquals(415, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('error', $json->get('type'));
+        $this->assertEquals(415, $json->get('http-code'));
+        $this->assertNotEmpty($json->get('message'));
+        $this->assertEquals('text/xml', $json->get('more-info')->get('request-content-type'));
+    }
+
+    public function testContentTypeNotSupportedEmpty() {
+        $result = ErrorResponse::contentTypeNotSupported('');
+
+        $json = $result['json'];
+        $this->assertEquals(415, $json->get('http-code'));
+        $this->assertFalse($json->hasKey('more-info'));
+    }
+}


### PR DESCRIPTION
# Summary
Extract standardized error response logic from `WebServicesManager` into a reusable `ErrorResponse` class. Step 2 of 5 in ADR-0005.

## Motivation
`WebServicesManager` has 8 methods for sending error responses that are reusable patterns not tied to the manager. Extracting them enables reuse by the future `RequestProcessor` and makes error formatting testable in isolation. Fixes #119.

## Changes
- Created `WebFiori\Http\ErrorResponse` class with static methods:
  - `invalidParams(array $params)`
  - `missingParams(array $params)`
  - `unauthorized(?string $message = null)`
  - `methodNotAllowed()`
  - `serviceNotFound()`
  - `serviceNotImplemented()`
  - `missingServiceName()`
  - `contentTypeNotSupported(string $type)`
- Each method returns `["json" => Json, "code" => int]` for caller flexibility
- Deprecated all corresponding `WebServicesManager` methods (delegate internally)

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/ErrorResponseTest.php
```
12 new tests, 44 assertions. Full suite: 518 tests pass.

## Breaking Changes and Migration Steps
None. Existing `WebServicesManager` methods still work, marked `@deprecated`.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #119
Part of ADR-0005: https://github.com/WebFiori/docs/blob/main/adr/0005-request-processor-replaces-manager.md