### PR TITLE
refactor(#120): extract OpenAPIGenerator from WebServicesManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ For more examples, check the [examples](examples/) directory in this repository.
 - [`APIFilter`](https://webfiori.com/docs/webfiori/http/APIFilter) - Input filtering and validation
 - [`Request`](https://webfiori.com/docs/webfiori/http/Request) - HTTP request utilities
 - [`Response`](https://webfiori.com/docs/webfiori/http/Response) - HTTP response utilities
+- [`ErrorResponse`](https://webfiori.com/docs/webfiori/http/ErrorResponse) - Standardized error response generation
+- [`OpenAPIGenerator`](https://webfiori.com/docs/webfiori/http/OpenAPI/OpenAPIGenerator) - Standalone OpenAPI spec generation
 
 ## Contributing
 

--- a/WebFiori/Http/OpenAPI/OpenAPIGenerator.php
+++ b/WebFiori/Http/OpenAPI/OpenAPIGenerator.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2019-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http\OpenAPI;
+
+use WebFiori\Http\WebService;
+
+/**
+ * Standalone generator for OpenAPI 3.x specifications from WebService instances.
+ * 
+ * This class decouples OpenAPI generation from WebServicesManager, allowing
+ * spec generation without a full manager setup.
+ *
+ * @author Ibrahim
+ */
+class OpenAPIGenerator {
+    /**
+     * Generates an OpenAPI specification from an array of web services.
+     * 
+     * @param WebService[] $services Array of web service instances.
+     * @param string $description API description for the info object.
+     * @param string $version API version string.
+     * @param string $basePath Base path prefix for all service routes.
+     * 
+     * @return OpenAPIObj The generated OpenAPI specification object.
+     */
+    public function generate(array $services, string $description = '', string $version = '1.0.0', string $basePath = '') : OpenAPIObj {
+        $info = new InfoObj($description, $version);
+        $openapi = new OpenAPIObj($info);
+        $paths = new PathsObj();
+
+        foreach ($services as $service) {
+            if ($service instanceof WebService) {
+                $path = $basePath.'/'.$service->getName();
+                $paths->addPath($path, $service->toPathItemObj());
+            }
+        }
+
+        $openapi->setPaths($paths);
+
+        return $openapi;
+    }
+}

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -887,29 +887,19 @@ class WebServicesManager implements JsonI {
     /**
      * Converts the services manager to an OpenAPI document.
      * 
-     * This method generates a complete OpenAPI 3.1.0 specification document
-     * from the registered services. Each service becomes a path in the document.
+     * @deprecated Use OpenAPI\OpenAPIGenerator::generate() instead.
      * 
      * @return OpenAPI\OpenAPIObj The OpenAPI document.
      */
     public function toOpenAPI(): OpenAPI\OpenAPIObj {
-        $info = new OpenAPI\InfoObj(
+        $generator = new OpenAPI\OpenAPIGenerator();
+
+        return $generator->generate(
+            $this->getServices(),
             $this->getDescription(),
-            $this->getVersion()
+            $this->getVersion(),
+            $this->getBasePath()
         );
-
-        $openapi = new OpenAPI\OpenAPIObj($info);
-
-        $paths = new OpenAPI\PathsObj();
-
-        foreach ($this->getServices() as $service) {
-            $path = $this->basePath.'/'.$service->getName();
-            $paths->addPath($path, $service->toPathItemObj());
-        }
-
-        $openapi->setPaths($paths);
-
-        return $openapi;
     }
     private function _AfterParamsCheck($processReq) {
         if ($processReq) {

--- a/examples/04-advanced/02-openapi-docs/README.md
+++ b/examples/04-advanced/02-openapi-docs/README.md
@@ -1,0 +1,71 @@
+# OpenAPI Documentation Generation
+
+Demonstrates generating OpenAPI 3.1 specifications using the standalone `OpenAPIGenerator` class.
+
+## What This Example Demonstrates
+
+- Generating OpenAPI specs without a `WebServicesManager`
+- Using `OpenAPIGenerator` directly with service instances
+- Setting API description, version, and base path
+- Outputting the spec as JSON
+
+## Files
+
+- [`index.php`](index.php) - Generates and outputs an OpenAPI spec
+
+## How to Run
+
+```bash
+php -S localhost:8080
+# Visit http://localhost:8080 to see the generated OpenAPI JSON
+```
+
+## Code Explanation
+
+### Standalone Generator (Recommended)
+
+```php
+use WebFiori\Http\OpenAPI\OpenAPIGenerator;
+
+$generator = new OpenAPIGenerator();
+$spec = $generator->generate(
+    [new UserService(), new TaskService()],  // Services
+    'My API',                                 // Description
+    '2.0.0',                                  // Version
+    '/api/v2'                                 // Base path
+);
+
+echo $spec->toJSON();
+```
+
+### Legacy Approach (Deprecated)
+
+```php
+$manager = new WebServicesManager();
+$manager->addService(new UserService());
+$manager->setDescription('My API');
+$manager->setVersion('2.0.0');
+$spec = $manager->toOpenAPI(); // @deprecated
+```
+
+### Output
+
+The generated spec follows OpenAPI 3.1.0 format:
+
+```json
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "My API",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/api/v2/users": {
+      "get": { ... },
+      "post": { ... }
+    }
+  }
+}
+```
+
+Parameters defined with `#[RequestParam]` are automatically included as query parameters (GET) or request body properties (POST/PUT/PATCH).

--- a/examples/04-advanced/02-openapi-docs/index.php
+++ b/examples/04-advanced/02-openapi-docs/index.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once '../../../vendor/autoload.php';
+
+use WebFiori\Http\OpenAPI\OpenAPIGenerator;
+use WebFiori\Http\WebService;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\ParamType;
+
+/**
+ * Example service for OpenAPI generation.
+ */
+#[RestController('users', 'User management')]
+class UserService extends WebService {
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('id', ParamType::INT, true)]
+    public function getUser(?int $id): array {
+        return ['id' => $id ?? 1, 'name' => 'John'];
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('name', ParamType::STRING)]
+    #[RequestParam('email', ParamType::EMAIL)]
+    public function createUser(string $name, string $email): array {
+        return ['id' => 2, 'name' => $name, 'email' => $email];
+    }
+
+    public function isAuthorized(): bool { return true; }
+    public function processRequest() {}
+}
+
+// Generate OpenAPI spec using the standalone generator
+$generator = new OpenAPIGenerator();
+$spec = $generator->generate(
+    [new UserService()],
+    'User Management API',
+    '1.0.0',
+    '/api/v1'
+);
+
+// Output as JSON
+header('Content-Type: application/json');
+echo $spec->toJSON();

--- a/tests/WebFiori/Tests/Http/OpenAPIGeneratorTest.php
+++ b/tests/WebFiori/Tests/Http/OpenAPIGeneratorTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Http\OpenAPI\OpenAPIGenerator;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\AnnotatedMethodService;
+use WebFiori\Tests\Http\TestServices\AllMethodsService;
+
+/**
+ * Tests for OpenAPIGenerator.
+ * 
+ * @see https://github.com/WebFiori/http/issues/120
+ */
+class OpenAPIGeneratorTest extends TestCase {
+
+    public function testGenerateWithSingleService() {
+        $generator = new OpenAPIGenerator();
+        $service = new AnnotatedMethodService();
+
+        $spec = $generator->generate([$service], 'Test API', '1.0.0');
+        $json = $spec->toJSON();
+
+        $this->assertEquals('3.1.0', $json->get('openapi'));
+        $this->assertEquals('Test API', $json->get('info')->get('title'));
+        $this->assertEquals('1.0.0', $json->get('info')->get('version'));
+        $this->assertTrue($json->get('paths')->hasKey('/' . $service->getName()));
+    }
+
+    public function testGenerateWithMultipleServices() {
+        $generator = new OpenAPIGenerator();
+        $service1 = new AnnotatedMethodService();
+        $service2 = new AllMethodsService();
+
+        $spec = $generator->generate([$service1, $service2], 'Multi API', '2.0.0');
+        $json = $spec->toJSON();
+
+        $this->assertTrue($json->get('paths')->hasKey('/' . $service1->getName()));
+        $this->assertTrue($json->get('paths')->hasKey('/' . $service2->getName()));
+    }
+
+    public function testGenerateWithBasePath() {
+        $generator = new OpenAPIGenerator();
+        $service = new AnnotatedMethodService();
+
+        $spec = $generator->generate([$service], 'API', '1.0.0', '/api/v2');
+        $json = $spec->toJSON();
+
+        $this->assertTrue($json->get('paths')->hasKey('/api/v2/' . $service->getName()));
+    }
+
+    public function testGenerateWithDescriptionAndVersion() {
+        $generator = new OpenAPIGenerator();
+
+        $spec = $generator->generate([], 'My Great API', '3.5.1');
+        $json = $spec->toJSON();
+
+        $this->assertEquals('My Great API', $json->get('info')->get('title'));
+        $this->assertEquals('3.5.1', $json->get('info')->get('version'));
+    }
+
+    public function testGenerateEmptyServices() {
+        $generator = new OpenAPIGenerator();
+
+        $spec = $generator->generate([]);
+        $json = $spec->toJSON();
+
+        $this->assertEquals('3.1.0', $json->get('openapi'));
+        // Paths object exists but has no paths
+        $this->assertNotNull($json->get('paths'));
+    }
+
+    public function testDeprecatedManagerMethodStillWorks() {
+        $manager = new WebServicesManager();
+        $manager->addService(new AnnotatedMethodService());
+        $manager->setDescription('Legacy API');
+        $manager->setVersion('1.2.3');
+        $manager->setBasePath('/legacy');
+
+        $spec = $manager->toOpenAPI();
+        $json = $spec->toJSON();
+
+        $this->assertEquals('Legacy API', $json->get('info')->get('title'));
+        $this->assertEquals('1.2.3', $json->get('info')->get('version'));
+        $service = new AnnotatedMethodService();
+        $this->assertTrue($json->get('paths')->hasKey('/legacy/' . $service->getName()));
+    }
+}


### PR DESCRIPTION
# Summary
Extract OpenAPI spec generation into a standalone `OpenAPIGenerator` class. Step 3 of 5 in ADR-0005.

## Motivation
`WebServicesManager::toOpenAPI()` is a documentation concern that does not belong in the request processing pipeline. Extracting it allows spec generation without a full manager setup. Fixes #120.

## Changes
- Created `WebFiori\Http\OpenAPI\OpenAPIGenerator` with `generate(array $services, string $description, string $version, string $basePath)` method
- Deprecated `WebServicesManager::toOpenAPI()`, delegates to generator internally
- Added example in `examples/04-advanced/02-openapi-docs/`
- Updated README key classes section with `ErrorResponse` and `OpenAPIGenerator`

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/OpenAPIGeneratorTest.php
```
6 new tests, 14 assertions. Full suite: 524 tests pass.

## Breaking Changes and Migration Steps
None. `WebServicesManager::toOpenAPI()` still works, marked `@deprecated`.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #120
Part of ADR-0005: https://github.com/WebFiori/docs/blob/main/adr/0005-request-processor-replaces-manager.md