### PR TITLE
feat(#121): create RequestProcessor class

### DIFF
--- a/WebFiori/Http/RequestProcessor.php
+++ b/WebFiori/Http/RequestProcessor.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2019-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http;
+
+/**
+ * Processes a single WebService against an HTTP request without requiring
+ * manual service registration or a full WebServicesManager setup.
+ * 
+ * This class provides a simplified entry point for processing a web service.
+ * It handles content type validation, HTTP method checking, parameter filtering,
+ * authorization, method invocation, and response serialization.
+ * 
+ * Usage:
+ * ```php
+ * $processor = new RequestProcessor();
+ * $processor->process(new MyService(), Request::createFromGlobals());
+ * ```
+ *
+ * @author Ibrahim
+ */
+class RequestProcessor {
+    /**
+     * Process a request against a specific web service.
+     * 
+     * The processor runs the full pipeline:
+     * 1. Content type validation
+     * 2. HTTP method matching
+     * 3. Parameter filtering and validation
+     * 4. Authorization check
+     * 5. Method invocation
+     * 6. Response serialization
+     * 
+     * @param WebService $service The service to process.
+     * @param Request|null $request The incoming HTTP request. If null, creates from globals.
+     * @param resource|null $outputStream Optional output stream for testing.
+     */
+    public function process(WebService $service, ?Request $request = null, $outputStream = null) : void {
+        if ($request === null) {
+            $request = Request::createFromGlobals();
+        }
+
+        $manager = new WebServicesManager($request);
+        $manager->addService($service);
+
+        if ($outputStream !== null) {
+            $manager->setOutputStream($outputStream);
+        }
+
+        $manager->process();
+    }
+}

--- a/examples/04-advanced/04-request-processor/README.md
+++ b/examples/04-advanced/04-request-processor/README.md
@@ -1,0 +1,63 @@
+# RequestProcessor — Standalone Service Processing
+
+Demonstrates processing a web service directly without a `WebServicesManager`.
+
+## What This Example Demonstrates
+
+- Using `RequestProcessor` to process a single service
+- No service registry or manager setup required
+- Automatic request creation from globals
+- Full pipeline: validation, auth, invocation, serialization
+
+## Files
+
+- [`index.php`](index.php) - Processes a service directly with RequestProcessor
+
+## How to Run
+
+```bash
+php -S localhost:8080
+```
+
+## Testing
+
+```bash
+# GET request
+curl "http://localhost:8080?name=Ibrahim"
+
+# GET without param (uses default)
+curl "http://localhost:8080"
+
+# POST request
+curl -X POST http://localhost:8080 \
+  -d "to=Alice&body=Hi there"
+```
+
+## Code Explanation
+
+### Before (WebServicesManager)
+
+```php
+$manager = new WebServicesManager();
+$manager->addService(new GreetService());
+$manager->process();
+```
+
+### After (RequestProcessor)
+
+```php
+$processor = new RequestProcessor();
+$processor->process(new GreetService());
+```
+
+The `RequestProcessor` is ideal when:
+- You have a router that already resolved which service to call
+- You want to process a single service without registry overhead
+- You're building framework integrations that handle routing externally
+
+### With explicit Request (for testing)
+
+```php
+$processor = new RequestProcessor();
+$processor->process(new GreetService(), $request, $outputStream);
+```

--- a/examples/04-advanced/04-request-processor/index.php
+++ b/examples/04-advanced/04-request-processor/index.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once '../../../vendor/autoload.php';
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\RequestProcessor;
+use WebFiori\Http\WebService;
+
+#[RestController('greet')]
+class GreetService extends WebService {
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('name', ParamType::STRING, true)]
+    public function hello(?string $name): array {
+        return ['message' => 'Hello, ' . ($name ?? 'World') . '!'];
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[RequestParam('to', ParamType::STRING)]
+    #[RequestParam('body', ParamType::STRING)]
+    public function sendGreeting(string $to, string $body): array {
+        return ['sent_to' => $to, 'body' => $body, 'timestamp' => time()];
+    }
+
+    public function isAuthorized(): bool { return true; }
+    public function processRequest() {}
+}
+
+// Process directly — no WebServicesManager needed
+$processor = new RequestProcessor();
+$processor->process(new GreetService());

--- a/tests/WebFiori/Tests/Http/RequestProcessorTest.php
+++ b/tests/WebFiori/Tests/Http/RequestProcessorTest.php
@@ -1,0 +1,162 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\Request;
+use WebFiori\Http\RequestProcessor;
+use WebFiori\Tests\Http\TestServices\AnnotatedMethodService;
+use WebFiori\Tests\Http\TestServices\AllMethodsService;
+use WebFiori\Tests\Http\TestServices\StringAuthDenialService;
+
+/**
+ * Tests for RequestProcessor.
+ * 
+ * @see https://github.com/WebFiori/http/issues/121
+ */
+class RequestProcessorTest extends APITestCase {
+
+    /**
+     * Test processing a GET request with ResponseBody annotation.
+     */
+    public function testProcessGetWithResponseBody() {
+        $processor = new RequestProcessor();
+        $service = new AnnotatedMethodService();
+
+        putenv('REQUEST_METHOD=GET');
+        $_GET = ['param1' => 'hello'];
+        $_SERVER['CONTENT_TYPE'] = '';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+        $request = Request::createFromGlobals();
+
+        $processor->process($service, $request, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $this->assertNotEmpty($output);
+    }
+
+    /**
+     * Test processing a POST request with parameter validation.
+     */
+    public function testProcessPostWithParams() {
+        $processor = new RequestProcessor();
+        $service = new AllMethodsService();
+
+        putenv('REQUEST_METHOD=POST');
+        $_POST = ['name' => 'John'];
+        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+        $request = Request::createFromGlobals();
+
+        $processor->process($service, $request, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $this->assertNotEmpty($output);
+    }
+
+    /**
+     * Test that unauthorized service returns 401.
+     */
+    public function testUnauthorizedReturnsError() {
+        $processor = new RequestProcessor();
+        $service = new StringAuthDenialService();
+
+        putenv('REQUEST_METHOD=GET');
+        $_GET = [];
+        $_SERVER['CONTENT_TYPE'] = '';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+        $request = Request::createFromGlobals();
+
+        $processor->process($service, $request, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+        $this->assertEquals('You must be a premium member to access this resource.', $response['message']);
+    }
+
+    /**
+     * Test that wrong HTTP method returns 405.
+     */
+    public function testMethodNotAllowed() {
+        $processor = new RequestProcessor();
+        $service = new AnnotatedMethodService();
+
+        putenv('REQUEST_METHOD=DELETE');
+        $_GET = [];
+        $_SERVER['CONTENT_TYPE'] = '';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+        $request = Request::createFromGlobals();
+
+        $processor->process($service, $request, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    /**
+     * Test that unsupported content type returns 415.
+     */
+    public function testContentTypeNotSupported() {
+        $processor = new RequestProcessor();
+        $service = new AllMethodsService();
+
+        putenv('REQUEST_METHOD=POST');
+        $_POST = [];
+        $_SERVER['CONTENT_TYPE'] = 'text/xml';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+        $request = Request::createFromGlobals();
+
+        $processor->process($service, $request, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    /**
+     * Test processing with null request (creates from globals).
+     */
+    public function testProcessWithNullRequest() {
+        $processor = new RequestProcessor();
+        $service = new AnnotatedMethodService();
+
+        putenv('REQUEST_METHOD=GET');
+        $_GET = ['param1' => 'test'];
+        $_SERVER['CONTENT_TYPE'] = '';
+
+        $outFile = $this->getOutputFile();
+        $stream = fopen($outFile, 'w');
+
+        $processor->process($service, null, $stream);
+
+        $output = file_get_contents($outFile);
+        @unlink($outFile);
+
+        $this->assertNotEmpty($output);
+    }
+}


### PR DESCRIPTION
# Summary
Create a `RequestProcessor` class that processes a single web service against an HTTP request without requiring manual service registration or a full `WebServicesManager` setup. Step 4 of 5 in ADR-0005.

## Motivation
Processing a `WebService` currently requires instantiating a full `WebServicesManager` with its registry. The `RequestProcessor` provides a simpler entry point when the caller already knows which service to invoke. Fixes #121.

## Changes
- Created `WebFiori\Http\RequestProcessor` with `process(WebService $service, ?Request $request, $outputStream)` method
- Leverages `WebServicesManager` internally (single-service auto-select mode)
- Added example in `examples/04-advanced/04-request-processor/`

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/RequestProcessorTest.php
```
6 new tests, 11 assertions. Full suite: 530 tests pass.

## Breaking Changes and Migration Steps
None. New class — purely additive.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #121
Part of ADR-0005: https://github.com/WebFiori/docs/blob/main/adr/0005-request-processor-replaces-manager.md