### PR TITLE
deprecate(#122): mark WebServicesManager as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,14 @@ class HelloService extends AbstractWebService {
 }
 ```
 
-Both approaches work with `WebServicesManager`:
+Both approaches work with `RequestProcessor` (recommended) or `WebServicesManager`:
 
 ```php
+// Recommended: process a single service directly
+$processor = new RequestProcessor();
+$processor->process(new HelloService());
+
+// Legacy: register services in a manager
 $manager = new WebServicesManager();
 $manager->addService(new HelloService());
 $manager->process();

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -20,9 +20,22 @@ use WebFiori\Json\JsonI;
  * is used to group related services. For example, if we have creat, read, write and
  * delete services, they can be added to one instance of this class.
  * 
- * When a request is made to the services set, An instance of the class must be created 
- * and the method <a href="#process">WebServicesManager::process()</a> must be called.
+ * @deprecated Use RequestProcessor for processing individual services directly.
  * 
+ * Migration:
+ * ```php
+ * // Before:
+ * $manager = new WebServicesManager();
+ * $manager->addService(new MyService());
+ * $manager->process();
+ * 
+ * // After:
+ * $processor = new RequestProcessor();
+ * $processor->process(new MyService());
+ * ```
+ * 
+ * For OpenAPI generation, use OpenAPI\OpenAPIGenerator.
+ * For error responses, use ErrorResponse.
  */
 class WebServicesManager implements JsonI {
     /**
@@ -492,8 +505,7 @@ class WebServicesManager implements JsonI {
     /**
      * Process user request.
      *
-     * This method must be called after creating any
-     * new instance of the class in order to process user request.
+     * @deprecated Use RequestProcessor::process() instead for processing individual services.
      *
      * @throws Exception
      */
@@ -677,6 +689,7 @@ class WebServicesManager implements JsonI {
      * string, an object... . If null is given, the parameter 'more-info' 
      * will be not included in response. Default is empty string. Default is null.
      * 
+     * @deprecated Use ErrorResponse or Response directly instead.
      */
     public function sendResponse(string $message, int $code = 200, string $type = '', mixed $otherInfo = '') {
         $json = new Json();


### PR DESCRIPTION
# Summary
Mark `WebServicesManager` as deprecated, completing the ADR-0005 refactoring chain. Step 5 of 5.

## Motivation
With `RequestProcessor`, `ErrorResponse`, and `OpenAPIGenerator` in place, `WebServicesManager` is now a legacy wrapper. New code should use `RequestProcessor` directly. Fixes #122.

## Changes
- Added `@deprecated` to `WebServicesManager` class docblock with migration guide
- Added `@deprecated` to `process()` and `sendResponse()` methods
- Updated README Quick Start to show `RequestProcessor` as the recommended approach
- Registry methods (`addService`, `getServices`, etc.) remain undeprecated for backward compat

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/
```
530 tests pass unchanged — full backward compatibility.

## Breaking Changes and Migration Steps
None. All existing code continues to work. Deprecation annotations guide migration:

```php
// Before:
$manager = new WebServicesManager();
$manager->addService(new MyService());
$manager->process();

// After:
$processor = new RequestProcessor();
$processor->process(new MyService());
```

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #122
Completes ADR-0005: https://github.com/WebFiori/docs/blob/main/adr/0005-request-processor-replaces-manager.md