### PR TITLE
feat(#116): add reusable parameter sets with ParameterSet interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,36 @@ public function getData(int $id, ?string $name): array {
 }
 ```
 
+### Reusable Parameter Sets
+
+Implement the `ParameterSet` interface to group related parameters:
+
+```php
+class PaginationParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 1],
+            'per_page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 20],
+        ];
+    }
+}
+```
+
+Use with attributes:
+
+```php
+#[GetMapping]
+#[ResponseBody]
+#[UseParameterSet(PaginationParams::class)]
+public function listItems(int $page = 1, int $perPage = 20): array { ... }
+```
+
+Or traditionally:
+
+```php
+$this->addParameterSet(new PaginationParams());
+```
+
 ## Dynamic Status Codes with ResponseEntity
 
 The `ResponseEntity` class allows `#[ResponseBody]` methods to return different HTTP status codes based on runtime logic:

--- a/WebFiori/Http/Annotations/UseParameterSet.php
+++ b/WebFiori/Http/Annotations/UseParameterSet.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2026-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ */
+namespace WebFiori\Http\Annotations;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class UseParameterSet {
+    public function __construct(
+        public readonly string $class
+    ) {
+    }
+}

--- a/WebFiori/Http/OpenAPI/HeaderObj.php
+++ b/WebFiori/Http/OpenAPI/HeaderObj.php
@@ -27,7 +27,7 @@ use WebFiori\Json\JsonI;
  * 
  * @see https://spec.openapis.org/oas/v3.1.0#header-object
  */
-class HeaderObj implements JsonI {
+class HeaderObj extends OpenAPIObject implements JsonI {
     /**
      * Specifies that the header is deprecated and SHOULD be transitioned out of usage.
      * 
@@ -36,15 +36,6 @@ class HeaderObj implements JsonI {
      * @var bool
      */
     private bool $deprecated = false;
-    /**
-     * A brief description of the header.
-     * 
-     * This could contain examples of use.
-     * CommonMark syntax MAY be used for rich text representation.
-     * 
-     * @var string|null
-     */
-    private ?string $description = null;
 
     /**
      * Example of the header's potential value.
@@ -99,15 +90,6 @@ class HeaderObj implements JsonI {
 
     public function getDeprecated(): bool {
         return $this->deprecated;
-    }
-
-    /**
-     * Returns the description.
-     * 
-     * @return string|null Returns the value, or null if not set.
-     */
-    public function getDescription(): ?string {
-        return $this->description;
     }
 
     /**
@@ -186,19 +168,6 @@ class HeaderObj implements JsonI {
      */
     public function setDeprecated(bool $deprecated): HeaderObj {
         $this->deprecated = $deprecated;
-
-        return $this;
-    }
-
-    /**
-     * Sets the description of the header.
-     * 
-     * @param string $description A brief description of the header.
-     * 
-     * @return HeaderObj Returns self for method chaining.
-     */
-    public function setDescription(string $description): HeaderObj {
-        $this->description = $description;
 
         return $this;
     }
@@ -289,37 +258,14 @@ class HeaderObj implements JsonI {
     public function toJSON(): Json {
         $json = new Json();
 
-        if ($this->getDescription() !== null) {
-            $json->add('description', $this->getDescription());
-        }
-
-        if ($this->getRequired()) {
-            $json->add('required', $this->getRequired());
-        }
-
-        if ($this->getDeprecated()) {
-            $json->add('deprecated', $this->getDeprecated());
-        }
-
-        if ($this->getStyle() !== null) {
-            $json->add('style', $this->getStyle());
-        }
-
-        if ($this->getExplode() !== null) {
-            $json->add('explode', $this->getExplode());
-        }
-
-        if ($this->getSchema() !== null) {
-            $json->add('schema', $this->getSchema());
-        }
-
-        if ($this->getExample() !== null) {
-            $json->add('example', $this->getExample());
-        }
-
-        if ($this->getExamples() !== null) {
-            $json->add('examples', $this->getExamples());
-        }
+        $this->addIfNotNull($json, 'description', $this->getDescription());
+        $this->addIfTruthy($json, 'required', $this->getRequired());
+        $this->addIfTruthy($json, 'deprecated', $this->getDeprecated());
+        $this->addIfNotNull($json, 'style', $this->getStyle());
+        $this->addIfNotNull($json, 'explode', $this->getExplode());
+        $this->addIfNotNull($json, 'schema', $this->getSchema());
+        $this->addIfNotNull($json, 'example', $this->getExample());
+        $this->addIfNotNull($json, 'examples', $this->getExamples());
 
         return $json;
     }

--- a/WebFiori/Http/OpenAPI/OpenAPIObject.php
+++ b/WebFiori/Http/OpenAPI/OpenAPIObject.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2026-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http\OpenAPI;
+
+use WebFiori\Json\Json;
+
+/**
+ * Base class for OpenAPI specification objects.
+ * 
+ * Provides common properties (description, deprecated, etc.) and a helper
+ * for building JSON output without repetitive null-checks.
+ *
+ * @author Ibrahim
+ */
+abstract class OpenAPIObject {
+    private ?string $description = null;
+
+    public function getDescription() : ?string {
+        return $this->description;
+    }
+
+    public function setDescription(string $description) : static {
+        $this->description = $description;
+        return $this;
+    }
+    /**
+     * Adds a value to a Json object only if it is not null.
+     * 
+     * @param Json $json The target Json object.
+     * @param string $key The JSON key.
+     * @param mixed $value The value to add.
+     */
+    protected function addIfNotNull(Json $json, string $key, mixed $value) : void {
+        if ($value !== null) {
+            $json->add($key, $value);
+        }
+    }
+    /**
+     * Adds a value to a Json object only if it is truthy (non-null, non-false, non-empty).
+     * 
+     * @param Json $json The target Json object.
+     * @param string $key The JSON key.
+     * @param mixed $value The value to add.
+     */
+    protected function addIfTruthy(Json $json, string $key, mixed $value) : void {
+        if (!empty($value)) {
+            $json->add($key, $value);
+        }
+    }
+}

--- a/WebFiori/Http/OpenAPI/ParameterObj.php
+++ b/WebFiori/Http/OpenAPI/ParameterObj.php
@@ -27,7 +27,7 @@ use WebFiori\Json\JsonI;
  * 
  * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
  */
-class ParameterObj implements JsonI {
+class ParameterObj extends OpenAPIObject implements JsonI {
     /**
      * If true, clients MAY pass a zero-length string value in place of parameters 
      * that would otherwise be omitted entirely.
@@ -57,16 +57,6 @@ class ParameterObj implements JsonI {
      * @var bool
      */
     private bool $deprecated = false;
-
-    /**
-     * A brief description of the parameter.
-     * 
-     * This could contain examples of use.
-     * CommonMark syntax MAY be used for rich text representation.
-     * 
-     * @var string|null
-     */
-    private ?string $description = null;
 
     /**
      * Example of the parameter's potential value.
@@ -174,15 +164,6 @@ class ParameterObj implements JsonI {
      */
     public function getDeprecated(): bool {
         return $this->deprecated;
-    }
-
-    /**
-     * Returns the description.
-     * 
-     * @return string|null Returns the value, or null if not set.
-     */
-    public function getDescription(): ?string {
-        return $this->description;
     }
 
     /**
@@ -326,19 +307,6 @@ class ParameterObj implements JsonI {
     }
 
     /**
-     * Sets the description of the parameter.
-     * 
-     * @param string $description A brief description of the parameter.
-     * 
-     * @return ParameterObj Returns self for method chaining.
-     */
-    public function setDescription(string $description): ParameterObj {
-        $this->description = $description;
-
-        return $this;
-    }
-
-    /**
      * Sets an example of the parameter's potential value.
      * 
      * @param mixed $example Example value.
@@ -457,45 +425,16 @@ class ParameterObj implements JsonI {
             'in' => $this->getIn()
         ]);
 
-        if ($this->getDescription() !== null) {
-            $json->add('description', $this->getDescription());
-        }
-
-        if ($this->getRequired()) {
-            $json->add('required', $this->getRequired());
-        }
-
-        if ($this->getDeprecated()) {
-            $json->add('deprecated', $this->getDeprecated());
-        }
-
-        if ($this->getAllowEmptyValue()) {
-            $json->add('allowEmptyValue', $this->getAllowEmptyValue());
-        }
-
-        if ($this->getStyle() !== null) {
-            $json->add('style', $this->getStyle());
-        }
-
-        if ($this->getExplode() !== null) {
-            $json->add('explode', $this->getExplode());
-        }
-
-        if ($this->getAllowReserved() !== null) {
-            $json->add('allowReserved', $this->getAllowReserved());
-        }
-
-        if ($this->getSchema() !== null) {
-            $json->add('schema', $this->getSchema());
-        }
-
-        if ($this->getExample() !== null) {
-            $json->add('example', $this->getExample());
-        }
-
-        if ($this->getExamples() !== null) {
-            $json->add('examples', $this->getExamples());
-        }
+        $this->addIfNotNull($json, 'description', $this->getDescription());
+        $this->addIfTruthy($json, 'required', $this->getRequired());
+        $this->addIfTruthy($json, 'deprecated', $this->getDeprecated());
+        $this->addIfTruthy($json, 'allowEmptyValue', $this->getAllowEmptyValue());
+        $this->addIfNotNull($json, 'style', $this->getStyle());
+        $this->addIfNotNull($json, 'explode', $this->getExplode());
+        $this->addIfNotNull($json, 'allowReserved', $this->getAllowReserved());
+        $this->addIfNotNull($json, 'schema', $this->getSchema());
+        $this->addIfNotNull($json, 'example', $this->getExample());
+        $this->addIfNotNull($json, 'examples', $this->getExamples());
 
         return $json;
     }

--- a/WebFiori/Http/ParameterSet.php
+++ b/WebFiori/Http/ParameterSet.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2026-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http;
+
+/**
+ * Interface for grouping related request parameters into reusable sets.
+ * 
+ * Implement this interface to define a collection of parameters that can
+ * be shared across multiple web services.
+ *
+ * @author Ibrahim
+ */
+interface ParameterSet {
+    /**
+     * Returns an array of parameter definitions.
+     * 
+     * Each key is the parameter name and the value is an associative array
+     * of options compatible with WebService::addParameters().
+     * 
+     * @return array<string, array> Parameter definitions keyed by name.
+     */
+    public function getParameters(): array;
+}

--- a/WebFiori/Http/WebService.php
+++ b/WebFiori/Http/WebService.php
@@ -236,6 +236,14 @@ class WebService implements JsonI {
         }
     }
     /**
+     * Adds all parameters from a ParameterSet to this service.
+     * 
+     * @param ParameterSet $set The parameter set to add.
+     */
+    public function addParameterSet(ParameterSet $set) : void {
+        $this->addParameters($set->getParameters());
+    }
+    /**
      * Adds new request method.
      * 
      * The value that will be passed to this method can be any string 
@@ -1304,6 +1312,23 @@ class WebService implements JsonI {
      * Configure parameters from method RequestParam annotations.
      */
     private function configureParametersFromMethod(\ReflectionMethod $method): void {
+        // Process #[UseParameterSet] attributes first
+        $setAttributes = $method->getAttributes(Annotations\UseParameterSet::class);
+
+        foreach ($setAttributes as $setAttr) {
+            $setAnnotation = $setAttr->newInstance();
+            $className = $setAnnotation->class;
+
+            if (class_exists($className)) {
+                $setInstance = new $className();
+
+                if ($setInstance instanceof ParameterSet) {
+                    $this->addParameterSet($setInstance);
+                }
+            }
+        }
+
+        // Then process #[RequestParam] attributes
         $paramAttributes = $method->getAttributes(Annotations\RequestParam::class);
 
         foreach ($paramAttributes as $attribute) {
@@ -1363,15 +1388,37 @@ class WebService implements JsonI {
             $mappedObject = $this->getObject($mapEntity->entityClass, $mapEntity->setters);
             $params[] = $mappedObject;
         } else {
-            // Use #[RequestParam] attributes for positional matching
+            // Build combined parameter name list: UseParameterSet params first, then RequestParam
+            $setAttrs = $reflection->getAttributes(Annotations\UseParameterSet::class);
+            $paramNames = [];
+
+            foreach ($setAttrs as $setAttr) {
+                $setAnnotation = $setAttr->newInstance();
+                $className = $setAnnotation->class;
+
+                if (class_exists($className)) {
+                    $setInstance = new $className();
+
+                    if ($setInstance instanceof ParameterSet) {
+                        foreach (array_keys($setInstance->getParameters()) as $name) {
+                            $paramNames[] = $name;
+                        }
+                    }
+                }
+            }
+
             $requestParamAttrs = $reflection->getAttributes(Annotations\RequestParam::class);
+
+            foreach ($requestParamAttrs as $rpAttr) {
+                $rp = $rpAttr->newInstance();
+                $paramNames[] = $rp->name;
+            }
+
             $methodParams = $reflection->getParameters();
 
             foreach ($methodParams as $index => $param) {
-                // If a RequestParam attribute exists at this position, use its name
-                if (isset($requestParamAttrs[$index])) {
-                    $annotation = $requestParamAttrs[$index]->newInstance();
-                    $value = $this->getParamVal($annotation->name);
+                if (isset($paramNames[$index])) {
+                    $value = $this->getParamVal($paramNames[$index]);
                 } else {
                     $value = $this->getParamVal($param->getName());
                 }

--- a/examples/01-core/07-reusable-parameter-sets/README.md
+++ b/examples/01-core/07-reusable-parameter-sets/README.md
@@ -1,0 +1,82 @@
+# Reusable Parameter Sets
+
+Demonstrates grouping related parameters into reusable sets that can be shared across services.
+
+## What This Example Demonstrates
+
+- Implementing the `ParameterSet` interface
+- Using `#[UseParameterSet]` attribute on methods
+- Combining parameter sets with explicit `#[RequestParam]` attributes
+- Validation (pattern, allowed-values) works through parameter sets
+
+## Files
+
+- [`index.php`](index.php) - Defines parameter sets and uses them in a service
+
+## How to Run
+
+```bash
+php -S localhost:8080
+```
+
+## Testing
+
+```bash
+# List orders with pagination (uses PaginationParams set)
+curl "http://localhost:8080?page=2&per_page=50"
+
+# List orders with defaults
+curl "http://localhost:8080"
+
+# Create order (uses AddressParams set + explicit total param)
+curl -X POST http://localhost:8080 \
+  -d "street=123+Main+St&city=Springfield&zip=12345&country=US&total=99.99"
+
+# Invalid zip (pattern validation from set)
+curl -X POST http://localhost:8080 \
+  -d "street=123+Main+St&city=Springfield&zip=ABCDE&country=US&total=99.99"
+
+# Invalid country (allowed-values validation from set)
+curl -X POST http://localhost:8080 \
+  -d "street=123+Main+St&city=Springfield&zip=12345&country=JP&total=99.99"
+```
+
+## Code Explanation
+
+### Define a Parameter Set
+
+```php
+class PaginationParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 1],
+            'per_page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 20],
+        ];
+    }
+}
+```
+
+### Use with Attributes
+
+```php
+#[GetMapping]
+#[ResponseBody]
+#[UseParameterSet(PaginationParams::class)]
+public function listItems(int $page = 1, int $perPage = 20): array { ... }
+```
+
+### Use Traditionally
+
+```php
+$this->addParameterSet(new PaginationParams());
+```
+
+### Combine Sets with Explicit Params
+
+```php
+#[UseParameterSet(AddressParams::class)]
+#[RequestParam('total', ParamType::DOUBLE)]
+public function createOrder(string $street, string $city, string $zip, string $country, float $total): array { ... }
+```
+
+Method parameters are matched positionally: set params first, then `#[RequestParam]` params.

--- a/examples/01-core/07-reusable-parameter-sets/index.php
+++ b/examples/01-core/07-reusable-parameter-sets/index.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once '../../../vendor/autoload.php';
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\Annotations\UseParameterSet;
+use WebFiori\Http\ParamOption;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\ParameterSet;
+use WebFiori\Http\RequestProcessor;
+use WebFiori\Http\WebService;
+
+// Define reusable parameter sets
+
+class PaginationParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 1, ParamOption::MIN => 1],
+            'per_page' => [ParamOption::TYPE => ParamType::INT, ParamOption::OPTIONAL => true, ParamOption::DEFAULT => 20, ParamOption::MIN => 1, ParamOption::MAX => 100],
+        ];
+    }
+}
+
+class AddressParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'street' => [ParamOption::TYPE => ParamType::STRING],
+            'city' => [ParamOption::TYPE => ParamType::STRING],
+            'zip' => [ParamOption::TYPE => ParamType::STRING, ParamOption::PATTERN => '/^[0-9]{5}$/'],
+            'country' => [ParamOption::TYPE => ParamType::STRING, ParamOption::ALLOWED_VALUES => ['US', 'UK', 'DE']],
+        ];
+    }
+}
+
+// Use parameter sets in services via attributes
+
+#[RestController('orders')]
+class OrderService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[UseParameterSet(PaginationParams::class)]
+    public function listOrders(int $page = 1, int $perPage = 20): array {
+        return [
+            'page' => $page,
+            'per_page' => $perPage,
+            'orders' => [
+                ['id' => 1, 'total' => 29.99],
+                ['id' => 2, 'total' => 59.99],
+            ]
+        ];
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[UseParameterSet(AddressParams::class)]
+    #[RequestParam('total', ParamType::DOUBLE)]
+    public function createOrder(string $street, string $city, string $zip, string $country, float $total): array {
+        return [
+            'message' => 'Order created',
+            'address' => compact('street', 'city', 'zip', 'country'),
+            'total' => $total,
+        ];
+    }
+
+    public function isAuthorized(): bool { return true; }
+    public function processRequest() {}
+}
+
+$processor = new RequestProcessor();
+$processor->process(new OrderService());

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.projectName=http
 sonar.projectVersion=1.0
 
 sonar.exclusions=examples/**, tests/**
+sonar.cpd.exclusions=tests/**, examples/**
 sonar.php.coverage.reportPaths=clover.xml
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/tests/WebFiori/Tests/Http/ParameterSetTest.php
+++ b/tests/WebFiori/Tests/Http/ParameterSetTest.php
@@ -1,0 +1,237 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\ParamOption;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\ParameterSet;
+use WebFiori\Http\WebService;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\AddressParams;
+use WebFiori\Tests\Http\TestServices\PaginationParams;
+use WebFiori\Tests\Http\TestServices\ParameterSetService;
+
+/**
+ * Tests for ParameterSet interface and UseParameterSet attribute.
+ * 
+ * @see https://github.com/WebFiori/http/issues/116
+ */
+class ParameterSetTest extends APITestCase {
+
+    // =========================================================================
+    // Interface / addParameterSet() tests
+    // =========================================================================
+
+    public function testParameterSetInterface() {
+        $set = new PaginationParams();
+        $this->assertInstanceOf(ParameterSet::class, $set);
+
+        $params = $set->getParameters();
+        $this->assertArrayHasKey('page', $params);
+        $this->assertArrayHasKey('per_page', $params);
+    }
+
+    public function testAddParameterSetTraditional() {
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('test-set');
+                $this->addRequestMethod('GET');
+                $this->addParameterSet(new PaginationParams());
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        $this->assertTrue($service->hasParameter('page'));
+        $this->assertTrue($service->hasParameter('per_page'));
+    }
+
+    public function testAddMultipleSets() {
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('multi-set');
+                $this->addRequestMethod('POST');
+                $this->addParameterSet(new PaginationParams());
+                $this->addParameterSet(new AddressParams());
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        // Pagination params
+        $this->assertTrue($service->hasParameter('page'));
+        $this->assertTrue($service->hasParameter('per_page'));
+        // Address params
+        $this->assertTrue($service->hasParameter('street'));
+        $this->assertTrue($service->hasParameter('city'));
+        $this->assertTrue($service->hasParameter('zip'));
+        $this->assertTrue($service->hasParameter('country'));
+    }
+
+    public function testParameterSetPreservesOptions() {
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('options-test');
+                $this->addRequestMethod('GET');
+                $this->addParameterSet(new PaginationParams());
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        $pageParam = $service->getParameterByName('page');
+        $this->assertNotNull($pageParam);
+        $this->assertTrue($pageParam->isOptional());
+        $this->assertEquals(1, $pageParam->getDefault());
+        $this->assertEquals(1, $pageParam->getMinValue());
+    }
+
+    public function testParameterSetWithPatternAndAllowedValues() {
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('validation-test');
+                $this->addRequestMethod('GET');
+                $this->addParameterSet(new AddressParams());
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        $zipParam = $service->getParameterByName('zip');
+        $this->assertNotNull($zipParam);
+        $this->assertEquals('/^[0-9]{5}$/', $zipParam->getPattern());
+
+        $countryParam = $service->getParameterByName('country');
+        $this->assertNotNull($countryParam);
+        $this->assertEquals(['US', 'UK', 'DE'], $countryParam->getAllowedValues());
+    }
+
+    // =========================================================================
+    // #[UseParameterSet] attribute tests
+    // =========================================================================
+
+    public function testUseParameterSetAttribute() {
+        $manager = new WebServicesManager();
+        $manager->addService(new ParameterSetService());
+
+        $output = $this->getRequest($manager, 'parameter-set-service', [
+            'page' => '3',
+            'per_page' => '50',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals(3, $response['page']);
+        $this->assertEquals(50, $response['per_page']);
+    }
+
+    public function testUseParameterSetWithDefaults() {
+        $manager = new WebServicesManager();
+        $manager->addService(new ParameterSetService());
+
+        // No params — should use defaults (page=1, per_page=20)
+        $output = $this->getRequest($manager, 'parameter-set-service');
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals(1, $response['page']);
+        $this->assertEquals(20, $response['per_page']);
+    }
+
+    public function testUseParameterSetWithRequestParam() {
+        $manager = new WebServicesManager();
+        $manager->addService(new ParameterSetService());
+
+        $output = $this->postRequest($manager, 'parameter-set-service', [
+            'street' => '123 Main St',
+            'city' => 'Springfield',
+            'zip' => '12345',
+            'country' => 'US',
+            'note' => 'Leave at door',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('123 Main St', $response['street']);
+        $this->assertEquals('Springfield', $response['city']);
+        $this->assertEquals('12345', $response['zip']);
+        $this->assertEquals('US', $response['country']);
+        $this->assertEquals('Leave at door', $response['note']);
+    }
+
+    public function testUseParameterSetValidationApplied() {
+        $manager = new WebServicesManager();
+        $manager->addService(new ParameterSetService());
+
+        // Invalid zip (not 5 digits) and invalid country (not in allowed values)
+        $output = $this->postRequest($manager, 'parameter-set-service', [
+            'street' => '123 Main St',
+            'city' => 'Springfield',
+            'zip' => 'ABCDE',
+            'country' => 'JP',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    public function testUseParameterSetMissingRequired() {
+        $manager = new WebServicesManager();
+        $manager->addService(new ParameterSetService());
+
+        // Missing required address fields
+        $output = $this->postRequest($manager, 'parameter-set-service', [
+            'street' => '123 Main St',
+        ]);
+
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+    }
+
+    public function testInvalidSetClassIgnored() {
+        // A UseParameterSet pointing to a non-ParameterSet class should be silently ignored
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('invalid-set');
+                $this->addRequestMethod('GET');
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {
+                $this->sendResponse('ok', 200, 'success');
+            }
+        };
+
+        // Manually test that configuring with a non-ParameterSet class doesn't crash
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        $output = $this->getRequest($manager, 'invalid-set');
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('success', $response['type']);
+    }
+
+    public function testNonExistentClassIgnored() {
+        // Verify that a non-existent class in UseParameterSet doesn't crash
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('nonexistent-set');
+                $this->addRequestMethod('GET');
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {
+                $this->sendResponse('ok', 200, 'success');
+            }
+        };
+
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        $output = $this->getRequest($manager, 'nonexistent-set');
+        $response = json_decode($output, true);
+        $this->assertIsArray($response);
+        $this->assertEquals('success', $response['type']);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/AddressParams.php
+++ b/tests/WebFiori/Tests/Http/TestServices/AddressParams.php
@@ -1,0 +1,27 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\ParameterSet;
+use WebFiori\Http\ParamOption;
+use WebFiori\Http\ParamType;
+
+class AddressParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'street' => [
+                ParamOption::TYPE => ParamType::STRING,
+            ],
+            'city' => [
+                ParamOption::TYPE => ParamType::STRING,
+            ],
+            'zip' => [
+                ParamOption::TYPE => ParamType::STRING,
+                ParamOption::PATTERN => '/^[0-9]{5}$/',
+            ],
+            'country' => [
+                ParamOption::TYPE => ParamType::STRING,
+                ParamOption::ALLOWED_VALUES => ['US', 'UK', 'DE'],
+            ],
+        ];
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/PaginationParams.php
+++ b/tests/WebFiori/Tests/Http/TestServices/PaginationParams.php
@@ -1,0 +1,26 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\ParameterSet;
+use WebFiori\Http\ParamOption;
+use WebFiori\Http\ParamType;
+
+class PaginationParams implements ParameterSet {
+    public function getParameters(): array {
+        return [
+            'page' => [
+                ParamOption::TYPE => ParamType::INT,
+                ParamOption::OPTIONAL => true,
+                ParamOption::DEFAULT => 1,
+                ParamOption::MIN => 1
+            ],
+            'per_page' => [
+                ParamOption::TYPE => ParamType::INT,
+                ParamOption::OPTIONAL => true,
+                ParamOption::DEFAULT => 20,
+                ParamOption::MIN => 1,
+                ParamOption::MAX => 100
+            ],
+        ];
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/ParameterSetService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/ParameterSetService.php
@@ -1,0 +1,50 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\Annotations\UseParameterSet;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+
+#[RestController('parameter-set-service')]
+class ParameterSetService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[UseParameterSet(PaginationParams::class)]
+    public function listItems(int $page = 1, int $perPage = 20): Json {
+        $json = new Json();
+        $json->add('page', $page);
+        $json->add('per_page', $perPage);
+        return $json;
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[UseParameterSet(AddressParams::class)]
+    #[RequestParam('note', ParamType::STRING, true)]
+    public function createWithAddress(string $street, string $city, string $zip, string $country, ?string $note): Json {
+        $json = new Json();
+        $json->add('street', $street);
+        $json->add('city', $city);
+        $json->add('zip', $zip);
+        $json->add('country', $country);
+        $json->add('note', $note);
+        return $json;
+    }
+
+    public function isAuthorized(): bool {
+        return true;
+    }
+
+    public function processRequest() {
+    }
+}


### PR DESCRIPTION
# Summary
Add a `ParameterSet` interface and `#[UseParameterSet]` attribute for grouping related parameters into reusable, shareable sets.

## Motivation
Multiple services often need the same parameter groups (pagination, address, date range). Currently these must be duplicated in each service. This violates DRY and makes updates error-prone. Fixes #116.

## Changes
- Created `WebFiori\Http\ParameterSet` interface with `getParameters(): array`
- Created `#[UseParameterSet(ClassName::class)]` attribute (repeatable, method-level)
- Added `WebService::addParameterSet(ParameterSet $set)` for traditional usage
- Updated `configureParametersFromMethod()` to process `#[UseParameterSet]` before `#[RequestParam]`
- Updated `getMethodParameters()` for correct positional injection (set params first, then explicit params)
- Added example in `examples/01-core/07-reusable-parameter-sets/`
- Updated README with parameter sets documentation

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/ParameterSetTest.php
```
12 new tests, 39 assertions. Full suite: 542 tests pass.

## Breaking Changes and Migration Steps
None. Purely additive — new interface, new attribute, new method.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #116