### PR TITLE
feat(#117): #[RequiresAuth] checks SecurityContext::isAuthenticated() directly

### DIFF
--- a/WebFiori/Http/WebService.php
+++ b/WebFiori/Http/WebService.php
@@ -328,8 +328,8 @@ class WebService implements JsonI {
 
         // Check RequiresAuth
         if ($hasRequiresAuth) {
-            // First call isAuthorized()
-            if (!$this->isAuthorized()) {
+            // Check SecurityContext directly instead of isAuthorized()
+            if (!SecurityContext::isAuthenticated()) {
                 return false;
             }
 
@@ -353,6 +353,11 @@ class WebService implements JsonI {
             $preAuth = $preAuthAttributes[0]->newInstance();
 
             return SecurityContext::evaluateExpression($preAuth->expression);
+        }
+
+        // If class has #[RequiresAuth], check SecurityContext
+        if ($this->hasClassLevelRequiresAuth()) {
+            return SecurityContext::isAuthenticated();
         }
 
         return $this->isAuthorized();
@@ -688,6 +693,16 @@ class WebService implements JsonI {
      */
     public function isAuthRequired() : bool {
         return $this->requireAuth;
+    }
+    /**
+     * Checks if the class has a #[RequiresAuth] attribute.
+     * 
+     * @return bool True if the class-level RequiresAuth annotation is present.
+     */
+    public function hasClassLevelRequiresAuth() : bool {
+        $reflection = new \ReflectionClass($this);
+
+        return !empty($reflection->getAttributes(Annotations\RequiresAuth::class));
     }
 
     /**

--- a/WebFiori/Http/WebServicesManager.php
+++ b/WebFiori/Http/WebServicesManager.php
@@ -1130,6 +1130,11 @@ class WebServicesManager implements JsonI {
                 return $service->checkMethodAuthorization();
             }
 
+            // If class-level #[RequiresAuth] is present, check SecurityContext
+            if ($service->hasClassLevelRequiresAuth()) {
+                return SecurityContext::isAuthenticated();
+            }
+
             // Fall back to legacy HTTP-method-specific authorization
             $isAuthCheck = 'isAuthorized'.$this->getRequest()->getMethod();
 

--- a/tests/WebFiori/Tests/Http/RequiresAuthSecurityContextTest.php
+++ b/tests/WebFiori/Tests/Http/RequiresAuthSecurityContextTest.php
@@ -1,0 +1,161 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\APITestCase;
+use WebFiori\Http\SecurityContext;
+use WebFiori\Tests\Http\TestUser;
+use WebFiori\Http\WebServicesManager;
+use WebFiori\Tests\Http\TestServices\ClassRequiresAuthService;
+use WebFiori\Tests\Http\TestServices\MethodRequiresAuthService;
+
+/**
+ * Tests for #[RequiresAuth] checking SecurityContext::isAuthenticated() directly.
+ * 
+ * @see https://github.com/WebFiori/http/issues/117
+ */
+class RequiresAuthSecurityContextTest extends APITestCase {
+
+    // =========================================================================
+    // Method-level #[RequiresAuth]
+    // =========================================================================
+
+    public function testMethodRequiresAuthWithUser() {
+        $user = new TestUser(1, ['USER'], [], true);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new MethodRequiresAuthService());
+
+        $output = $this->getRequest($manager, 'method-requires-auth', [], [], $user);
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('method-level-protected', $response['secret']);
+    }
+
+    public function testMethodRequiresAuthWithoutUser() {
+        SecurityContext::setCurrentUser(null);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new MethodRequiresAuthService());
+
+        $output = $this->getRequest($manager, 'method-requires-auth');
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+    }
+
+    public function testMethodRequiresAuthIgnoresIsAuthorized() {
+        $user = new TestUser(2, ['ADMIN'], [], true);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new MethodRequiresAuthService());
+
+        $output = $this->getRequest($manager, 'method-requires-auth', [], [], $user);
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('method-level-protected', $response['secret']);
+    }
+
+    // =========================================================================
+    // Class-level #[RequiresAuth]
+    // =========================================================================
+
+    public function testClassRequiresAuthWithUser() {
+        $user = new TestUser(3, ['USER'], [], true);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new ClassRequiresAuthService());
+
+        $output = $this->getRequest($manager, 'class-requires-auth', [], [], $user);
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('class-level-protected', $response['secret']);
+    }
+
+    public function testClassRequiresAuthWithoutUser() {
+        SecurityContext::setCurrentUser(null);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new ClassRequiresAuthService());
+
+        $output = $this->getRequest($manager, 'class-requires-auth');
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+    }
+
+    public function testClassRequiresAuthMethodAllowAnonymous() {
+        // Class has #[RequiresAuth] but method has #[AllowAnonymous]
+        SecurityContext::setCurrentUser(null);
+
+        $manager = new WebServicesManager();
+        $manager->addService(new ClassRequiresAuthService());
+
+        $output = $this->postRequest($manager, 'class-requires-auth');
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals(true, $response['public']);
+    }
+
+    // =========================================================================
+    // No attributes — traditional fallback
+    // =========================================================================
+
+    public function testNoAttributesFallsBackToIsAuthorized() {
+        $service = new class extends \WebFiori\Http\WebService {
+            public function __construct() {
+                parent::__construct('no-attr-deny');
+                $this->addRequestMethod('GET');
+                $this->setIsAuthRequired(true);
+            }
+            public function isAuthorized(): bool {
+                return false;
+            }
+            public function processRequest() {
+                $this->sendResponse('should not reach', 200, 'success');
+            }
+        };
+
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        $output = $this->getRequest($manager, 'no-attr-deny');
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('error', $response['type']);
+        $this->assertEquals(401, $response['http-code']);
+    }
+
+    public function testNoAttributesIsAuthorizedTrue() {
+        $service = new class extends \WebFiori\Http\WebService {
+            public function __construct() {
+                parent::__construct('no-attr-allow');
+                $this->addRequestMethod('GET');
+                $this->setIsAuthRequired(true);
+            }
+            public function isAuthorized(): bool {
+                return true;
+            }
+            public function processRequest() {
+                $this->sendResponse('allowed', 200, 'success');
+            }
+        };
+
+        $manager = new WebServicesManager();
+        $manager->addService($service);
+
+        $output = $this->getRequest($manager, 'no-attr-allow');
+        $response = json_decode($output, true);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('success', $response['type']);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/ClassRequiresAuthService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/ClassRequiresAuthService.php
@@ -1,0 +1,44 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\PostMapping;
+use WebFiori\Http\Annotations\RequiresAuth;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+
+/**
+ * Service with class-level #[RequiresAuth].
+ * isAuthorized() intentionally returns false to prove SecurityContext is used instead.
+ */
+#[RestController('class-requires-auth')]
+#[RequiresAuth]
+class ClassRequiresAuthService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    public function getProtectedData(): Json {
+        $json = new Json();
+        $json->add('secret', 'class-level-protected');
+        return $json;
+    }
+
+    #[PostMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    public function publicEndpoint(): Json {
+        $json = new Json();
+        $json->add('public', true);
+        return $json;
+    }
+
+    public function isAuthorized(): bool {
+        return false; // Should NOT matter when #[RequiresAuth] is on class
+    }
+
+    public function processRequest() {
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/MethodRequiresAuthService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/MethodRequiresAuthService.php
@@ -1,0 +1,33 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\RequiresAuth;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+
+/**
+ * Service with method-level #[RequiresAuth] only.
+ * isAuthorized() returns false to prove it's not called.
+ */
+#[RestController('method-requires-auth')]
+class MethodRequiresAuthService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    #[RequiresAuth]
+    public function getSecretData(): Json {
+        $json = new Json();
+        $json->add('secret', 'method-level-protected');
+        return $json;
+    }
+
+    public function isAuthorized(): bool {
+        return false; // Should NOT matter when #[RequiresAuth] is on method
+    }
+
+    public function processRequest() {
+    }
+}


### PR DESCRIPTION
# Summary
Make `#[RequiresAuth]` check `SecurityContext::isAuthenticated()` instead of calling `isAuthorized()` (which defaults to `false`). Implements ADR-0003.

## Motivation
`#[RequiresAuth]` was effectively broken — it called `isAuthorized()` which defaults to `false`, requiring every service to override it with boilerplate. The attribute name implies "check if user is authenticated," which is what `SecurityContext::isAuthenticated()` does. Fixes #117.

## Changes
- `checkMethodAuthorization()`: method-level `#[RequiresAuth]` now checks `SecurityContext::isAuthenticated()`
- `checkMethodAuthorization()`: when method has no auth annotations, checks class-level `#[RequiresAuth]` before falling back to `isAuthorized()`
- `WebServicesManager::isAuth()`: class-level `#[RequiresAuth]` with no method annotations checks `SecurityContext::isAuthenticated()`
- Added `WebService::hasClassLevelRequiresAuth()` helper

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/RequiresAuthSecurityContextTest.php
```
8 new tests, 19 assertions. Full suite: 550 tests pass.

## Breaking Changes and Migration Steps
Behavior change for services using `#[RequiresAuth]`:
- **Before**: always denied (because `isAuthorized()` defaults to `false`)
- **After**: checks `SecurityContext::isAuthenticated()` (works as intended)

Services without auth attributes are unchanged.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #117
ADR: https://github.com/WebFiori/docs/blob/main/adr/0003-requires-auth-security-context.md