### PR TITLE
feat: add content negotiation with #[Produces] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,33 @@ For more examples, check the [examples](examples/) directory in this repository.
 - [`ErrorResponse`](https://webfiori.com/docs/webfiori/http/ErrorResponse) - Standardized error response generation
 - [`OpenAPIGenerator`](https://webfiori.com/docs/webfiori/http/OpenAPI/OpenAPIGenerator) - Standalone OpenAPI spec generation
 
+### Content Negotiation
+
+Use `#[Produces]` to declare what content types a method can return. The framework matches against the client's `Accept` header:
+
+```php
+use WebFiori\Http\Annotations\Produces;
+use WebFiori\Http\MediaType;
+use WebFiori\Http\ResponseEntity;
+
+#[GetMapping]
+#[ResponseBody]
+#[Produces(MediaType::JSON, MediaType::XML)]
+public function getUser(int $id): ResponseEntity {
+    $type = $this->getNegotiatedContentType();
+
+    if ($type === MediaType::XML) {
+        return new ResponseEntity('<user>...</user>', 200, MediaType::XML);
+    }
+
+    return ResponseEntity::ok(new Json(['id' => $id]));
+}
+```
+
+- No `#[Produces]` → always JSON (default, unchanged)
+- `Accept` header doesn't match → 406 Not Acceptable
+- `Accept: */*` or not set → server's first preference
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.

--- a/WebFiori/Http/Annotations/Produces.php
+++ b/WebFiori/Http/Annotations/Produces.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2026-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ */
+namespace WebFiori\Http\Annotations;
+
+use Attribute;
+
+/**
+ * Declares the content types a method can produce.
+ * 
+ * Used for content negotiation — the framework matches the client's Accept
+ * header against the declared types. If no match, returns 406 Not Acceptable.
+ * 
+ * Usage:
+ * ```php
+ * #[Produces(MediaType::JSON, MediaType::XML)]
+ * public function getUser(): ResponseEntity { ... }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class Produces {
+    public readonly array $contentTypes;
+
+    public function __construct(string ...$contentTypes) {
+        $this->contentTypes = $contentTypes;
+    }
+}

--- a/WebFiori/Http/ErrorResponse.php
+++ b/WebFiori/Http/ErrorResponse.php
@@ -143,6 +143,25 @@ class ErrorResponse {
         return ['json' => $json, 'code' => 401];
     }
     /**
+     * Generates a 406 Not Acceptable response.
+     * 
+     * @param array $supported The content types the server can produce.
+     * 
+     * @return array{json: Json, code: int} The response body and HTTP code.
+     */
+    public static function notAcceptable(array $supported = []) : array {
+        $json = new Json();
+        $json->add('message', 'Not Acceptable');
+        $json->add('type', WebService::E);
+        $json->add('http-code', 406);
+
+        if (!empty($supported)) {
+            $json->add('more-info', new Json(['supported' => $supported]));
+        }
+
+        return ['json' => $json, 'code' => 406];
+    }
+    /**
      * Formats an array of parameter names into a comma-separated quoted string.
      */
     private static function formatParamNames(array $params) : string {

--- a/WebFiori/Http/MediaType.php
+++ b/WebFiori/Http/MediaType.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ * 
+ * Copyright (c) 2026-present WebFiori Framework
+ * 
+ * For more information on the license, please visit: 
+ * https://github.com/WebFiori/http/blob/master/LICENSE
+ */
+namespace WebFiori\Http;
+
+/**
+ * Constants for common HTTP media types (MIME types).
+ * 
+ * Use with #[Produces] attribute for content negotiation.
+ *
+ * @author Ibrahim
+ */
+class MediaType {
+    const CSV = 'text/csv';
+    const FORM = 'application/x-www-form-urlencoded';
+    const HTML = 'text/html';
+    const JSON = 'application/json';
+    const MULTIPART = 'multipart/form-data';
+    const OCTET_STREAM = 'application/octet-stream';
+    const PDF = 'application/pdf';
+    const PLAIN = 'text/plain';
+    const XML = 'application/xml';
+}

--- a/WebFiori/Http/WebService.php
+++ b/WebFiori/Http/WebService.php
@@ -94,6 +94,12 @@ class WebService implements JsonI {
      */
     private $requireAuth;
     /**
+     * The content type negotiated from the Accept header.
+     * 
+     * @var string|null
+     */
+    private $negotiatedContentType;
+    /**
      * An array that contains descriptions of 
      * possible responses.
      * 
@@ -695,6 +701,17 @@ class WebService implements JsonI {
         return $this->requireAuth;
     }
     /**
+     * Returns the content type negotiated from the client's Accept header.
+     * 
+     * Only meaningful when the method has a #[Produces] attribute.
+     * Defaults to 'application/json' if no negotiation occurred.
+     * 
+     * @return string The negotiated media type.
+     */
+    public function getNegotiatedContentType() : string {
+        return $this->negotiatedContentType ?? MediaType::JSON;
+    }
+    /**
      * Checks if the class has a #[RequiresAuth] attribute.
      * 
      * @return bool True if the class-level RequiresAuth annotation is present.
@@ -765,6 +782,21 @@ class WebService implements JsonI {
 
                 return;
             }
+
+            // Content negotiation
+            $negotiated = $this->negotiateContentType($targetMethod);
+
+            if ($negotiated === null) {
+                $reflection = new \ReflectionMethod($this, $targetMethod);
+                $producesAttrs = $reflection->getAttributes(Annotations\Produces::class);
+                $supported = !empty($producesAttrs) ? $producesAttrs[0]->newInstance()->contentTypes : [MediaType::JSON];
+                $result = ErrorResponse::notAcceptable($supported);
+                $this->getManager()->send('application/json', $result['json'], $result['code']);
+
+                return;
+            }
+
+            $this->negotiatedContentType = $negotiated;
 
             try {
                 // Run cross-field validation
@@ -1352,6 +1384,86 @@ class WebService implements JsonI {
         }
     }
 
+    /**
+     * Performs content negotiation for a method.
+     * 
+     * @param string $methodName The target method name.
+     * 
+     * @return string|null The negotiated content type, or null if no match (406).
+     */
+    private function negotiateContentType(string $methodName): ?string {
+        $reflection = new \ReflectionMethod($this, $methodName);
+        $producesAttrs = $reflection->getAttributes(Annotations\Produces::class);
+
+        if (empty($producesAttrs)) {
+            return MediaType::JSON;
+        }
+
+        $produces = $producesAttrs[0]->newInstance()->contentTypes;
+        $acceptHeader = $this->getAcceptHeader();
+
+        if (empty($acceptHeader)) {
+            return $produces[0];
+        }
+
+        $accepted = self::parseAcceptHeader($acceptHeader);
+
+        foreach ($accepted as $mediaType) {
+            if ($mediaType['type'] === '*/*' || $mediaType['type'] === 'application/*') {
+                return $produces[0];
+            }
+
+            if (in_array($mediaType['type'], $produces, true)) {
+                return $mediaType['type'];
+            }
+        }
+
+        return null;
+    }
+    /**
+     * Gets the Accept header value from the current request.
+     */
+    private function getAcceptHeader(): string {
+        $manager = $this->getManager();
+
+        if ($manager !== null) {
+            $accept = $manager->getRequest()->getHeader('accept');
+
+            return !empty($accept) ? $accept[0] : '';
+        }
+
+        return $_SERVER['HTTP_ACCEPT'] ?? '';
+    }
+    /**
+     * Parses an Accept header into a sorted list of media types by q-value.
+     * 
+     * @param string $header The raw Accept header value.
+     * 
+     * @return array Sorted array of ['type' => string, 'q' => float].
+     */
+    private static function parseAcceptHeader(string $header): array {
+        $types = [];
+
+        foreach (explode(',', $header) as $part) {
+            $segments = explode(';', trim($part));
+            $mediaType = trim($segments[0]);
+            $q = 1.0;
+
+            foreach ($segments as $segment) {
+                $segment = trim($segment);
+
+                if (str_starts_with($segment, 'q=')) {
+                    $q = (float) substr($segment, 2);
+                }
+            }
+
+            $types[] = ['type' => $mediaType, 'q' => $q];
+        }
+
+        usort($types, fn($a, $b) => $b['q'] <=> $a['q']);
+
+        return $types;
+    }
     /**
      * Runs cross-field validation: service-wide validate() + method-specific #[Validate].
      * 

--- a/tests/WebFiori/Tests/Http/ContentNegotiationTest.php
+++ b/tests/WebFiori/Tests/Http/ContentNegotiationTest.php
@@ -1,0 +1,174 @@
+<?php
+namespace WebFiori\Tests\Http;
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\Produces;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\ErrorResponse;
+use WebFiori\Http\MediaType;
+use WebFiori\Http\ResponseEntity;
+use WebFiori\Http\Test\ServiceTestCase;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+use WebFiori\Tests\Http\TestServices\ContentNegotiationService;
+
+/**
+ * Tests for content negotiation with #[Produces] attribute.
+ */
+class ContentNegotiationTest extends ServiceTestCase {
+
+    // =========================================================================
+    // No #[Produces] — default behavior unchanged
+    // =========================================================================
+
+    public function testNoProducesNoAcceptReturnsJson() {
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('no-produces');
+                $this->addRequestMethod('GET');
+            }
+            #[GetMapping]
+            #[ResponseBody]
+            #[AllowAnonymous]
+            public function getData(): array {
+                return ['format' => 'json'];
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        $this->get($service)
+            ->assertOk()
+            ->assertJson();
+    }
+
+    public function testNoProducesWithAcceptXmlStillReturnsJson() {
+        // Without #[Produces], no negotiation happens — always JSON
+        $service = new class extends WebService {
+            public function __construct() {
+                parent::__construct('no-produces-xml');
+                $this->addRequestMethod('GET');
+            }
+            #[GetMapping]
+            #[ResponseBody]
+            #[AllowAnonymous]
+            public function getData(): array {
+                return ['format' => 'json'];
+            }
+            public function isAuthorized(): bool { return true; }
+            public function processRequest() {}
+        };
+
+        $this->get($service, [], null, ['accept' => 'application/xml'])
+            ->assertOk()
+            ->assertJson();
+    }
+
+    // =========================================================================
+    // #[Produces] with matching Accept
+    // =========================================================================
+
+    public function testProducesJsonAcceptJsonWorks() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'application/json'])
+            ->assertOk()
+            ->assertJson()
+            ->assertBodyContains('John');
+    }
+
+    public function testProducesXmlAcceptXmlWorks() {
+        $response = $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'application/xml']);
+        $this->assertStringContainsString('<user>', $response->getBody());
+        $this->assertStringContainsString('<name>John</name>', $response->getBody());
+    }
+
+    // =========================================================================
+    // #[Produces] with no match → 406
+    // =========================================================================
+
+    public function testProducesJsonXmlAcceptHtmlReturns406() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'text/html'])
+            ->assertStatus(406)
+            ->assertBodyContains('Not Acceptable');
+    }
+
+    public function testProducesAcceptPlainTextReturns406() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'text/plain'])
+            ->assertStatus(406);
+    }
+
+    // =========================================================================
+    // Wildcard and priority
+    // =========================================================================
+
+    public function testWildcardAcceptUsesServerDefault() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => '*/*'])
+            ->assertOk()
+            ->assertJson();
+    }
+
+    public function testApplicationWildcardWorks() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'application/*'])
+            ->assertOk();
+    }
+
+    public function testQValuePriorityRespected() {
+        // XML has higher priority (q=1.0) than JSON (q=0.5)
+        $response = $this->get(new ContentNegotiationService(), ['id' => '1'], null, [
+            'accept' => 'application/json;q=0.5, application/xml;q=1.0'
+        ]);
+        $this->assertStringContainsString('<user>', $response->getBody());
+    }
+
+    public function testQValueJsonHigherReturnsJson() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'], null, [
+            'accept' => 'application/json;q=1.0, application/xml;q=0.5'
+        ])
+            ->assertOk()
+            ->assertJson();
+    }
+
+    // =========================================================================
+    // No Accept header
+    // =========================================================================
+
+    public function testNoAcceptHeaderUsesServerDefault() {
+        $this->get(new ContentNegotiationService(), ['id' => '1'])
+            ->assertOk()
+            ->assertJson();
+    }
+
+    // =========================================================================
+    // getNegotiatedContentType()
+    // =========================================================================
+
+    public function testGetNegotiatedContentTypeReturnsXml() {
+        $response = $this->get(new ContentNegotiationService(), ['id' => '1'], null, ['accept' => 'application/xml']);
+        // The service uses getNegotiatedContentType() to decide format
+        $this->assertStringContainsString('<?xml', $response->getBody());
+    }
+
+    // =========================================================================
+    // ErrorResponse::notAcceptable
+    // =========================================================================
+
+    public function testNotAcceptableResponse() {
+        $result = ErrorResponse::notAcceptable([MediaType::JSON, MediaType::XML]);
+        $this->assertEquals(406, $result['code']);
+        $json = $result['json'];
+        $this->assertEquals('Not Acceptable', $json->get('message'));
+        $this->assertEquals(406, $json->get('http-code'));
+    }
+
+    // =========================================================================
+    // MediaType constants
+    // =========================================================================
+
+    public function testMediaTypeConstants() {
+        $this->assertEquals('application/json', MediaType::JSON);
+        $this->assertEquals('application/xml', MediaType::XML);
+        $this->assertEquals('text/html', MediaType::HTML);
+        $this->assertEquals('text/plain', MediaType::PLAIN);
+    }
+}

--- a/tests/WebFiori/Tests/Http/TestServices/ContentNegotiationService.php
+++ b/tests/WebFiori/Tests/Http/TestServices/ContentNegotiationService.php
@@ -1,0 +1,41 @@
+<?php
+namespace WebFiori\Tests\Http\TestServices;
+
+use WebFiori\Http\Annotations\AllowAnonymous;
+use WebFiori\Http\Annotations\GetMapping;
+use WebFiori\Http\Annotations\Produces;
+use WebFiori\Http\Annotations\RequestParam;
+use WebFiori\Http\Annotations\ResponseBody;
+use WebFiori\Http\Annotations\RestController;
+use WebFiori\Http\MediaType;
+use WebFiori\Http\ParamType;
+use WebFiori\Http\ResponseEntity;
+use WebFiori\Http\WebService;
+use WebFiori\Json\Json;
+
+#[RestController('content-negotiation-service')]
+class ContentNegotiationService extends WebService {
+
+    #[GetMapping]
+    #[ResponseBody]
+    #[AllowAnonymous]
+    #[Produces(MediaType::JSON, MediaType::XML)]
+    #[RequestParam('id', ParamType::INT, true, 1)]
+    public function getUser(int $id = 1): ResponseEntity {
+        $negotiated = $this->getNegotiatedContentType();
+
+        if ($negotiated === MediaType::XML) {
+            $xml = "<?xml version=\"1.0\"?><user><id>$id</id><name>John</name></user>";
+            return new ResponseEntity($xml, 200, MediaType::XML);
+        }
+
+        return ResponseEntity::ok(new Json(['id' => $id, 'name' => 'John']));
+    }
+
+    public function isAuthorized(): bool {
+        return true;
+    }
+
+    public function processRequest() {
+    }
+}


### PR DESCRIPTION
# Summary
Add HTTP content negotiation support via `#[Produces]` attribute and `MediaType` constants. Services can declare what content types they produce, and the framework matches against the client's `Accept` header.

## Motivation
Enterprise APIs behind gateways need proper 406 responses when clients request unsupported formats. The library always returned JSON regardless of the Accept header. This adds spec-compliant content negotiation (RFC 7231 §5.3.2).

## Changes
- `#[Produces(MediaType::JSON, MediaType::XML)]` attribute declares supported types
- `MediaType` class with constants for common MIME types
- `WebService::getNegotiatedContentType()` returns the matched type for the method to use
- `ErrorResponse::notAcceptable()` for 406 responses with supported types listed
- Negotiation runs in `processWithAutoHandling()` after auth, before validation
- Works with `ResponseEntity` — method sets content type based on negotiation result

## UI Changes
N/A

## How to Test / Verify
```bash
php vendor/bin/phpunit tests/WebFiori/Tests/Http/ContentNegotiationTest.php
```
14 new tests, 28 assertions. Full suite: 588 tests pass.

## Breaking Changes and Migration Steps
None. No `#[Produces]` = no negotiation = current behavior unchanged.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
N/A — new feature for HTTP spec compliance